### PR TITLE
fix: 修复部分机型内核日志读取不全，修复内核日志中hostname识别错误

### DIFF
--- a/application/logauththread.cpp
+++ b/application/logauththread.cpp
@@ -350,15 +350,11 @@ void LogAuthThread::handleKern()
 
             msg.dateTime = timeList.join(" ");
             QStringList tmpList;
-            utsname _utsname;
-            uname(&_utsname);
             if (list[0].contains("-")) {
-                // get hostname.
-                msg.hostName = QString(_utsname.nodename);
+                msg.hostName = list[2];
                 tmpList = list[3].split("[");
             } else {
-                // get hostname.
-                msg.hostName = QString(_utsname.nodename);
+                msg.hostName = list[3];
                 tmpList = list[4].split("[");
             }
 

--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -53,6 +53,16 @@ QString LogViewerService::readLog(const QString &filePath)
     m_process.start("cat", QStringList() << filePath);
     m_process.waitForFinished(-1);
     QByteArray byte = m_process.readAllStandardOutput();
+
+    //QByteArray -> QString 如果遇到0x00，会导致转换终止
+    //replace("\x00", "")和replace("\u0000", "")无效
+    for(int i = 0;i != byte.size();++i) {
+        if(byte.at(i) == 0x00) {
+            byte.remove(i, 1);
+            i--;
+        }
+    }
+
     return QString::fromUtf8(byte);
 }
 


### PR DESCRIPTION
QByteArray转换到QString中间出现0x00，导致转换被截断，需要预先剔除0x00
hostname一栏显示的是本机当前的hostname，并不是日志文件中的hostname

Log: 修复部分机型内核日志读取不全，修复内核日志中hostname识别错误
Bug: https://pms.uniontech.com/bug-view-147301.html