### PR TITLE
fix: 修复内核日志体量过大时导致的dbus崩溃

### DIFF
--- a/application/dbusproxy/dldbushandler.cpp
+++ b/application/dbusproxy/dldbushandler.cpp
@@ -61,6 +61,16 @@ QString DLDBusHandler::readLog(const QString &filePath)
     return m_dbus->readLog(filePath);
 }
 
+QString DLDBusHandler::openLogStream(const QString &filePath)
+{
+    return m_dbus->openLogStream(filePath);
+}
+
+QString DLDBusHandler::readLogInStream(const QString &token)
+{
+    return m_dbus->readLogInStream(token);
+}
+
 /*!
  * \~chinese \brief DLDBusHandler::exitCode 返回进程状态
  * \~chinese \return 进程返回值

--- a/application/dbusproxy/dldbushandler.h
+++ b/application/dbusproxy/dldbushandler.h
@@ -36,6 +36,8 @@ public:
     int exitCode();
     void quit();
     bool exportLog(const QString &outDir, const QString &in, bool isFile);
+    QString openLogStream(const QString &filePath);
+    QString readLogInStream(const QString &token);
 
 private:
     explicit DLDBusHandler(QObject *parent = nullptr);

--- a/application/dbusproxy/dldbusinterface.h
+++ b/application/dbusproxy/dldbusinterface.h
@@ -71,6 +71,20 @@ public Q_SLOTS: // METHODS
         return asyncCallWithArgumentList(QStringLiteral("readLog"), argumentList);
     }
 
+    inline QDBusPendingReply<QString> openLogStream(const QString &filePath)
+    {
+        QList<QVariant> argumentList;
+        argumentList << QVariant::fromValue(filePath);
+        return asyncCallWithArgumentList(QStringLiteral("openLogStream"), argumentList);
+    }
+
+    inline QDBusPendingReply<QString> readLogInStream(const QString &token)
+    {
+        QList<QVariant> argumentList;
+        argumentList << QVariant::fromValue(token);
+        return asyncCallWithArgumentList(QStringLiteral("readLogInStream"), argumentList);
+    }
+
 Q_SIGNALS: // SIGNALS
 };
 

--- a/application/logauththread.cpp
+++ b/application/logauththread.cpp
@@ -315,7 +315,19 @@ void LogAuthThread::handleKern()
         if (!m_canRun) {
             return;
         }
-        QString byte = DLDBusHandler::instance(this)->readLog(m_FilePath.at(i));
+
+        auto token = DLDBusHandler::instance(this)->openLogStream(m_FilePath.at(i));
+        QString byte;
+        while(1) {
+            auto temp = DLDBusHandler::instance(this)->readLogInStream(token);
+
+            if(temp.isEmpty()) {
+                break;
+            }
+
+            byte += temp;
+        }
+
         byte.replace('\u0000', "").replace("\x01", "");
         QStringList strList = byte.split('\n', QString::SkipEmptyParts);
         for (int j = strList.size() - 1; j >= 0; --j) {

--- a/logViewerService/assets/data/com.deepin.logviewer.xml
+++ b/logViewerService/assets/data/com.deepin.logviewer.xml
@@ -11,15 +11,23 @@
     <method name="quit">
     </method>
     <method name="exportLog"> 
-    <arg type="b" direction="out"/>
-    <arg name="outDir" type="s" direction="in"/>
-    <arg name="in" type="s" direction="in"/>
-    <arg name="isFile" type="b" direction="in"/>
+      <arg type="b" direction="out"/>
+      <arg name="outDir" type="s" direction="in"/>
+      <arg name="in" type="s" direction="in"/>
+      <arg name="isFile" type="b" direction="in"/>
     </method>
     <method name="getFileInfo"> 
-    <arg type="as" direction="out"/>
-    <arg name="file" type="s" direction="in"/>
-    <arg name="unzip" type="b" direction="in"/>
+      <arg type="as" direction="out"/>
+      <arg name="file" type="s" direction="in"/>
+      <arg name="unzip" type="b" direction="in"/>
+    </method>
+    <method name="openLogStream">
+      <arg type="s" direction="out"/>
+      <arg name="filePath" type="s" direction="in"/>
+    </method>
+    <method name="readLogInStream">
+      <arg type="s" direction="out"/>
+      <arg name="token" type="s" direction="in"/>
     </method>
   </interface>
 </node>

--- a/logViewerService/logviewerservice.h
+++ b/logViewerService/logviewerservice.h
@@ -28,6 +28,8 @@
 #include <QProcess>
 #include <QTemporaryDir>
 
+class QTextStream;
+
 class LogViewerService : public QObject
     , protected QDBusContext
 {
@@ -35,6 +37,7 @@ class LogViewerService : public QObject
     Q_CLASSINFO("D-Bus Interface", "com.deepin.logviewer")
 public:
     explicit LogViewerService(QObject *parent = nullptr);
+    ~LogViewerService();
 
 Q_SIGNALS:
 
@@ -44,12 +47,15 @@ public Q_SLOTS:
     Q_SCRIPTABLE void quit();
     Q_SCRIPTABLE QStringList getFileInfo(const QString &file, bool unzip = true);
     Q_SCRIPTABLE bool exportLog(const QString &outDir, const QString &in, bool isFile);
+    Q_SCRIPTABLE QString openLogStream(const QString &filePath);
+    Q_SCRIPTABLE QString readLogInStream(const QString &token);
 
 private:
     QTemporaryDir tmpDir;
     QProcess m_process;
     QString tmpDirPath;
     QMap<QString, QString> m_commands;
+    QMap<QString, std::pair<QString, QTextStream*>> m_logMap;
     /**
      * @brief isValidInvoker 检验调研者是否是日志
      * @return

--- a/tests/src/ut_logauththread.cpp
+++ b/tests/src/ut_logauththread.cpp
@@ -108,6 +108,20 @@ QString stub_dnfReadLog(const QString &filePath)
     return "2021-05-21T02:08:36Z DEBUG 加载插件：builddep, changelog, \nconfig-manager, copr, debug, debuginfo-install, download, \ngenerate_completion_cache, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync";
 }
 
+QString stub_dnfReadStream(const QString &filePath)
+{
+    Q_UNUSED(filePath);
+    static int i = 0;
+    QString result;
+    if(i % 2 == 0) {
+        result = "2021-05-21T02:08:36Z DEBUG 加载插件：builddep, changelog, \nconfig-manager, copr, debug, debuginfo-install, download, \ngenerate_completion_cache, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync";
+    } else {
+        result = "";
+    }
+    ++i;
+    return result;
+}
+
 QString stub_BootReadLog(const QString &filePath)
 {
     Q_UNUSED(filePath);
@@ -333,7 +347,8 @@ TEST_F(LogAuthThread_UT, UT_HandleKern_001)
     stub.set(wtmp_close, stub_wtmp_close);
     stub.set(ADDR(QProcess, setProcessChannelMode), stub_setProcessChannelMode);
     stub.set(ADDR(QProcess, exitCode), stub_exitCode);
-    stub.set(ADDR(DLDBusHandler, readLog), stub_dnfReadLog);
+    stub.set(ADDR(DLDBusHandler, openLogStream), stub_dnfReadLog);
+    stub.set(ADDR(DLDBusHandler, readLogInStream), stub_dnfReadStream);
     stub.set((QByteArray(QIODevice::*)(qint64))ADDR(QIODevice, readLine), fileReadLine);
     stub.set(ADDR(QDateTime, toMSecsSinceEpoch), dnfToMSecsSinceEpoch);
     stub.set(ADDR(QRegExp, indexIn), dmesgIndexIn);


### PR DESCRIPTION
原因是输入的内核日志文件达到接近40MB，超过了dbus的承载上限
修改方法是添加流式传输接口传输数据，防止dbus崩溃

Log: 修复内核日志体量过大时导致的dbus崩溃
Bug: https://pms.uniontech.com/bug-view-149507.html