### PR TITLE
fix: 修复导出日志可能带来的shell注入问题

### DIFF
--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -214,7 +214,8 @@ QStringList LogViewerService::getFileInfo(const QString &file, bool unzip)
 
 bool LogViewerService::exportLog(const QString &outDir, const QString &in, bool isFile)
 {
-    if (outDir.isEmpty() || in.isEmpty()) {
+    QFileInfo outDirInfo(outDir);
+    if (!outDirInfo.isDir() || in.isEmpty()) {
         return false;
     }
     QString outFullPath = "";


### PR DESCRIPTION
原因是未校验输出目录的路径，导致在特殊情况下可以进行shell注入
解决方法是添加输出目录的路径校验，必须路径存在才能执行后续操作

Log: 修复导出日志可能带来的shell注入问题