### PR TITLE
fix: 修复bug154893

### DIFF
--- a/application/logauththread.cpp
+++ b/application/logauththread.cpp
@@ -316,7 +316,18 @@ void LogAuthThread::handleKern()
             return;
         }
 
-        auto token = DLDBusHandler::instance(this)->openLogStream(m_FilePath.at(i));
+        //如果是压缩文件，对其解压缩
+        QString filePath = m_FilePath.at(i);
+        if(QString::compare(QFileInfo(filePath).suffix(), "gz", Qt::CaseInsensitive) == 0){
+            QStringList filePathList = DLDBusHandler::instance(this)->getFileInfo(filePath);
+            if(filePathList.size()){
+                filePath = filePathList.at(0);
+            }else {
+                filePath = "";
+            }
+        }
+
+        auto token = DLDBusHandler::instance(this)->openLogStream(filePath);
         QString byte;
         while(1) {
             auto temp = DLDBusHandler::instance(this)->readLogInStream(token);

--- a/application/logfileparser.cpp
+++ b/application/logfileparser.cpp
@@ -285,7 +285,7 @@ int LogFileParser::parseByKern(KERN_FILTERS &iKernFilter)
     m_isKernLoading = true;
     LogAuthThread   *authThread = new LogAuthThread(this);
     authThread->setType(KERN);
-    QStringList filePath = DLDBusHandler::instance(this)->getFileInfo("kern");
+    QStringList filePath = DLDBusHandler::instance(this)->getFileInfo("kern", false);
     authThread->setFileterParam(iKernFilter);
     authThread->setFilePath(filePath);
     connect(authThread, &LogAuthThread::kernFinished, this,

--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -189,9 +189,7 @@ QStringList LogViewerService::getFileInfo(const QString &file, bool unzip)
     dir.setSorting(QDir::Time);
     QFileInfoList fileList = dir.entryInfoList();
     for (int i = 0; i < fileList.count(); i++) {
-        if (QString::compare(fileList[i].suffix(), "gz", Qt::CaseInsensitive) != 0) {
-            fileNamePath.append(fileList[i].absoluteFilePath());
-        } else if (unzip) {
+        if (QString::compare(fileList[i].suffix(), "gz", Qt::CaseInsensitive) == 0 && unzip) {
             //                qDebug() << tmpDirPath;
             QProcess m_process;
 
@@ -206,6 +204,9 @@ QStringList LogViewerService::getFileInfo(const QString &file, bool unzip)
             //                qDebug() << m_process.readAll();
             fileNamePath.append(tmpDirPath + "/" + QString::number(fileNum) + ".txt");
             fileNum++;
+        }
+        else {
+            fileNamePath.append(fileList[i].absoluteFilePath());
         }
     }
     //       qInfo()<<fileNamePath.count()<<fileNamePath<<"******************************";


### PR DESCRIPTION
154893 【摸底】【日志收集工具】【E500-50258】刷新频率设置为10s后，切换到内核日志时应用卡死
原因分析：该函数会查找到所有内核日志文件，并返回文件名列表，同时会对所有文件解压缩，内核历史日志文件都挺大的，一次性全部解压缩就会很耗时。
解决办法：在查找所有内核日志文件名列表时，不解压缩文件，在内核日志解析线程中，解压一个处理一个，同时配合以前的解析500条记录就返回给界面展示的逻辑，可以解决该问题。

Log: 修复bug154893
Bug: https://pms.uniontech.com/bug-view-154893.html