### PR TITLE
Fix hardcoded path in logViewerService/logviewerservice.cpp

### DIFF
--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -12,8 +12,9 @@
 #include <QDBusConnection>
 #include <QDBusMessage>
 #include <QDBusConnectionInterface>
+#include <QStandardPaths>
 
-const QStringList ValidInvokerExePathList1 = {"/usr/bin/deepin-log-viewer"};
+const QStringList ValidInvokerExePathList1 = QStandardPaths::locateAll(QStandardPaths::ApplicationsLocation, "deepin-log-viewer");
 
 LogViewerService::LogViewerService(QObject *parent)
     : QObject(parent)


### PR DESCRIPTION
1 failed test before and after the modification (so probably unrelated to the change) by running `$PROJECT_ROOT/build/tests/deepin-log-viewer-test`:

```
[----------] Global test environment tear-down
[==========] 645 tests from 230 test cases ran. (13749 ms total)
[  PASSED  ] 644 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] LogApplicationHelper_getLogFile_UT.LogApplicationHelper_getLogFile_UT_002

 1 FAILED TEST
```