### PR TITLE
fix: avoid hardcoded exec path

### DIFF
--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -13,7 +13,7 @@
 #include <QDBusMessage>
 #include <QDBusConnectionInterface>
 
-const QStringList ValidInvokerExePathList1 = {"/usr/bin/deepin-log-viewer"};
+const QStringList ValidInvokerExePathList1 = QStandardPaths::locateAll(QStandardPaths::ApplicationsLocation, "deepin-log-viewer");
 
 LogViewerService::LogViewerService(QObject *parent)
     : QObject(parent)

--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -12,6 +12,7 @@
 #include <QDBusConnection>
 #include <QDBusMessage>
 #include <QDBusConnectionInterface>
+#include <QStandardPaths>
 
 const QStringList ValidInvokerExePathList1 = QStandardPaths::locateAll(QStandardPaths::ApplicationsLocation, "deepin-log-viewer");
 


### PR DESCRIPTION
Replace /usr/bin/deepin-log-viewer in logViewerService/logviewerservice.cpp with just deepin-log-viewer

Related: linuxdeepin/developer-center#3374

The commit message should be fixed now, please review the PR and merge if there are no outstanding issues, thanks :smile: