### PR TITLE
fix: 修复更新版本至5.9.14-1后，启动器和桌面的日志收集工具消失

### DIFF
--- a/debian/deepin-log-viewer.install
+++ b/debian/deepin-log-viewer.install
@@ -1,0 +1,11 @@
+usr/bin/deepin-log-viewer
+usr/bin/logViewerAuth
+usr/bin/logViewerTruncate
+usr/lib/deepin-daemon/log-view-service
+usr/share/applications/deepin-log-viewer.desktop
+usr/share/dbus-1/system-services/com.deepin.logviewer.service
+usr/share/dbus-1/system.d/com.deepin.logviewer.conf
+usr/share/deepin-log-viewer/DocxTemplate/*.dfw
+usr/share/deepin-log-viewer/translations/*.qm
+usr/share/polkit-1/actions/*.policy
+usr/share/icons/hicolor/scalable/apps/*.svg


### PR DESCRIPTION
Description: 提交deepin-log-viewer.install文件

Log: 修复更新版本至5.9.14-1后，启动器和桌面的日志收集工具消失
Bug: https://pms.uniontech.com/bug-view-182619.html