### PR TITLE
fix: 修复更新版本至5.9.14-1后，启动器和桌面的日志收集工具消失

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: deepin-log-viewer
 Section: utils
 Priority: optional
 Maintainer: Deepin Packages Builder <packages@deepin.org>
-Build-Depends: debhelper (>= 11),cmake, pkg-config, qtbase5-dev, qtchooser (>= 55-gc9562a1-1~),qt5-qmake, libdtkwidget-dev, libdtkgui-dev, qttools5-dev-tools, libqt5svg5-dev, libsystemd-dev, libicu-dev, qttools5-dev, libdframeworkdbus-dev, libgtest-dev, libgmock-dev, libkf5codecs-dev, libzip-dev, libxerces-c-dev, libboost-dev, libminizip-dev, libfftw3-3, rapidjson-dev, libltdl-dev, libpolkit-qt5-1-dev
+Build-Depends: debhelper (>= 11),cmake, pkg-config, qtbase5-dev, qtchooser (>= 55-gc9562a1-1~),qt5-qmake, libdtkwidget-dev, libdtkgui-dev, qttools5-dev-tools, libqt5svg5-dev, libsystemd-dev, libicu-dev, qttools5-dev, libdframeworkdbus-dev, libgtest-dev, libgmock-dev, libkf5codecs-dev, libzip-dev, libxerces-c-dev, libboost-dev, libminizip-dev, libfftw3-3 | libfftw3-dev, rapidjson-dev, libltdl-dev, libpolkit-qt5-1-dev
 Standards-Version: 4.1.3
 
 Package: deepin-log-viewer

--- a/debian/deepin-log-viewer.install
+++ b/debian/deepin-log-viewer.install
@@ -1,0 +1,11 @@
+usr/bin/deepin-log-viewer
+usr/bin/logViewerAuth
+usr/bin/logViewerTruncate
+usr/lib/deepin-daemon/log-view-service
+usr/share/applications/deepin-log-viewer.desktop
+usr/share/dbus-1/system-services/com.deepin.logviewer.service
+usr/share/dbus-1/system.d/com.deepin.logviewer.conf
+usr/share/deepin-log-viewer/DocxTemplate/*.dfw
+usr/share/deepin-log-viewer/translations/*.qm
+usr/share/polkit-1/actions/*.policy
+usr/share/icons/hicolor/scalable/apps/*.svg


### PR DESCRIPTION
Description: 提交deepin-log-viewer.install文件

Log: 修复更新版本至5.9.14-1后，启动器和桌面的日志收集工具消失
Bug: https://pms.uniontech.com/bug-view-182619.html