### PR TITLE
fix: 修复其他日志中，日志区域最小高度过大

### DIFF
--- a/application/displaycontent.cpp
+++ b/application/displaycontent.cpp
@@ -1489,12 +1489,14 @@ void DisplayContent::slot_logCatelogueClicked(const QModelIndex &index)
         m_flag = OtherLog;
         m_splitter->handle(3)->setDisabled(false);
         m_detailWgt->setFixedHeight(QWIDGETSIZE_MAX);
+        m_detailWgt->setMinimumHeight(70);
         createOOCTableForm();
         createOOCTable(LogApplicationHelper::instance()->getOtherLogList());
     } else if (itemData.contains(CUSTOM_TREE_DATA, Qt::CaseInsensitive)) {
         m_flag = CustomLog;
         m_splitter->handle(3)->setDisabled(false);
         m_detailWgt->setFixedHeight(QWIDGETSIZE_MAX);
+        m_detailWgt->setMinimumHeight(70);
         createOOCTableForm();
         createOOCTable(LogApplicationHelper::instance()->getCustomLogList());
     }


### PR DESCRIPTION
Description: 切换导航栏后，需要重新设置最小高度

Log: 修复其他日志中，日志区域最小高度过大
Bug: https://pms.uniontech.com/bug-view-182953.html