### PR TITLE
fix: 修复自定义日志配置，配置非text格式未忽略该文件

### DIFF
--- a/application/logapplicationhelper.cpp
+++ b/application/logapplicationhelper.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "logapplicationhelper.h"
+#include "utils.h"
 
 #include <QDebug>
 #include <QDir>
@@ -155,6 +156,10 @@ void LogApplicationHelper::initCustomLog()
         QString path = iter;
         if (path.startsWith("~/"))
             path.replace(0, 1, QDir::homePath());
+        //忽略非文本文件
+        if (!Utils::isTextFileType(path)) {
+            continue;
+        }
         m_custom_log_list.append(QStringList()<<QFileInfo(iter).fileName()<<path);
     }
 
@@ -177,6 +182,10 @@ void LogApplicationHelper::initCustomLog()
         QString path = iter;
         if (path.startsWith("~/"))
             path.replace(0, 1, QDir::homePath());
+        //忽略非文本文件
+        if (!Utils::isTextFileType(path)) {
+            continue;
+        }
         m_custom_log_list.append(QStringList()<<QFileInfo(iter).fileName()<<path);
     }
 }

--- a/application/utils.cpp
+++ b/application/utils.cpp
@@ -67,6 +67,16 @@ bool Utils::isFontMimeType(const QString &filePath)
     return false;
 }
 
+bool Utils::isTextFileType(const QString &filePath)
+{
+    QMimeDatabase db;
+    QMimeType mime = db.mimeTypeForFile(filePath);
+    if (mime.inherits("text/plain")) {
+        return true;
+    }
+    return false;
+}
+
 QString Utils::suffixList()
 {
     return QString("Font Files (*.ttf *.ttc *.otf)");

--- a/application/utils.h
+++ b/application/utils.h
@@ -32,6 +32,7 @@ public:
     static QString getQssContent(const QString &filePath);
     static QString getConfigPath();
     static bool isFontMimeType(const QString &filePath);
+    static bool isTextFileType(const QString &filePath);
     static QString suffixList();
     static QPixmap renderSVG(const QString &filePath, const QSize &size);
     static QString loadFontFamilyFromFiles(const QString &fontFileName);


### PR DESCRIPTION
Description: 添加过滤非text格式文件功能

Log: 修复自定义日志配置，配置非text格式未忽略该文件
Bug: https://pms.uniontech.com/bug-view-183011.html