### PR TITLE
fix: 修复gsetting配置自定义配置日志路径为空字符串，日志信息界面一直转圈

### DIFF
--- a/application/logoocfileparsethread.cpp
+++ b/application/logoocfileparsethread.cpp
@@ -54,18 +54,26 @@ void LogOOCFileParseThread::doWork()
     //此线程刚开始把可以继续变量置true，不然下面没法跑
     m_canRun = true;
 
+    if (m_path.isEmpty()) {
+        emit sigFinished(m_threadCount);
+        return;
+    }
+
     if (!checkAuthentication(m_path)) {
+        emit sigFinished(m_threadCount);
         return;
     }
 
     QStringList filePath = DLDBusHandler::instance(this)->getOtherFileInfo(m_path);
     for (int i = 0; i < filePath.count(); i++) {
         if (!m_canRun) {
+            emit sigFinished(m_threadCount);
             return;
         }
 
         //鉴权
         if (!checkAuthentication(filePath.at(i))) {
+            emit sigFinished(m_threadCount);
             return;
         }
 
@@ -95,7 +103,6 @@ bool LogOOCFileParseThread::checkAuthentication(const QString & path)
         m_process->waitForFinished(-1);
         //有错则传出空数据
         if (m_process->exitCode() != 0) {
-            emit sigFinished(m_threadCount, 1);
             return false;
         }
     }


### PR DESCRIPTION
Description: pkexec鉴权，如果路径传入为空，则一直阻塞没有返回值；增加路径为空判断

Log: 修复gsetting配置自定义配置日志路径为空字符串，日志信息界面一直转圈
Bug: https://pms.uniontech.com/bug-view-183371.html