### PR TITLE
fix: 修复其他日志中，选中任意日志文件，“导出”按钮不应该聚焦状态

### DIFF
--- a/application/displaycontent.cpp
+++ b/application/displaycontent.cpp
@@ -2716,9 +2716,9 @@ void DisplayContent::setLoadState(DisplayContent::LOAD_STATE iState)
     if (!noResultLabel->isHidden()) {
         noResultLabel->hide();
     }
-    if (!m_treeView->isHidden()) {
-        m_treeView->hide();
-    }
+//    if (!m_treeView->isHidden()) {
+//        m_treeView->hide();
+//    }
     switch (iState) {
     case DATA_LOADING: {
         //如果为正在加载,则不显示主表\搜索为空的提示lable,只显示加载的转圈动画控件,并且禁止导出,导出按钮置灰


### PR DESCRIPTION
Description: 列表控件隐藏，失去焦点，焦点自动调整到导出按钮上；状态切换，不用一开始就直接隐藏列表控件，有需要再隐藏

Log: 修复其他日志中，选中任意日志文件，“导出”按钮不应该聚焦状态
Bug: https://pms.uniontech.com/bug-view-182989.html