### PR TITLE
fix: 修复自定义日志配置无后缀名的文本文件，无法获取文本

### DIFF
--- a/application/displaycontent.cpp
+++ b/application/displaycontent.cpp
@@ -1383,8 +1383,6 @@ void DisplayContent::slot_BtnSelected(int btnId, int lId, QModelIndex idx)
              .arg(lId + 1)
              .arg(idx.data(ITEM_DATE_ROLE).toString());
 
-    m_detailWgt->cleanText();
-
     m_curLevel = lId; // m_curLevel equal combobox index-1;
     m_curBtnId = btnId;
 
@@ -1392,6 +1390,11 @@ void DisplayContent::slot_BtnSelected(int btnId, int lId, QModelIndex idx)
     if (treeData.isEmpty())
         return;
 
+    if (treeData.contains(OTHER_TREE_DATA, Qt::CaseInsensitive) || treeData.contains(CUSTOM_TREE_DATA, Qt::CaseInsensitive)) {
+        return;
+    }
+
+    m_detailWgt->cleanText();
     if (treeData.contains(JOUR_TREE_DATA, Qt::CaseInsensitive)) {
         generateJournalFile(btnId, m_curLevel);
     } else if (treeData.contains(BOOT_KLU_TREE_DATA, Qt::CaseInsensitive)) {
@@ -3215,6 +3218,7 @@ void DisplayContent::createOOCTable(const QList<QStringList> & list)
     if (p)
         p->select(m_pModel->index(0, 0), QItemSelectionModel::Rows | QItemSelectionModel::Select);
 
+    m_curTreeIndex = QModelIndex();//重置一下
     slot_tableItemClicked(m_pModel->index(0, 0));
 }
 

--- a/application/logoocfileparsethread.cpp
+++ b/application/logoocfileparsethread.cpp
@@ -145,7 +145,7 @@ bool LogOOCFileParseThread::checkAuthentication(const QString & path)
  */
 void LogOOCFileParseThread::run()
 {
-    qDebug() << "LogApplicationParseThread::run()---threadrun";
+    qDebug() << "LogOOCFileParseThread::run()---threadrun";
     doWork();
 }
 


### PR DESCRIPTION
Description: m_curTreeIndex标记没有重置，有几率会出现新旧标记相等而不刷新日志内容的情况

Log: 修复自定义日志配置无后缀名的文本文件，无法获取文本
Bug: https://pms.uniontech.com/bug-view-183671.html