### PR TITLE
fix: 修复导出所有日志未包含其它日志和自定义日志

### DIFF
--- a/application/logallexportthread.cpp
+++ b/application/logallexportthread.cpp
@@ -52,7 +52,18 @@ void LogAllExportThread::run()
             for (auto &it2 : appData.toStdMap()) {
                 files.append(it2.second);
             }
+        } else if (it.contains(OTHER_TREE_DATA, Qt::CaseInsensitive)) {
+            auto otherLogListPair = LogApplicationHelper::instance()->getOtherLogList();
+            for (auto &it2 : otherLogListPair) {
+                files.append(it2.at(1));
+            }
+        } else if (it.contains(CUSTOM_TREE_DATA, Qt::CaseInsensitive)) {
+            auto customLogListPair = LogApplicationHelper::instance()->getCustomLogList();
+            for (auto &it2 : customLogListPair) {
+                files.append(it2.at(1));
+            }
         }
+
         //取消导出直接返回
         if (m_cancel) {
             files.clear();


### PR DESCRIPTION
原因是在导出全部日志的时候没有将其它日志和自定义日志的路径加入导出列表中
解决方法是添加相关代码

Log: 修复导出所有日志未包含其它日志和自定义日志