### PR TITLE
fix: 修复自定义日志无法监控空白无后缀文件

### DIFF
--- a/application/logapplicationhelper.cpp
+++ b/application/logapplicationhelper.cpp
@@ -154,8 +154,8 @@ void LogApplicationHelper::initCustomLog()
         QString path = iter;
         if (path.startsWith("~/"))
             path.replace(0, 1, QDir::homePath());
-        //忽略非文本文件
-        if (!Utils::isTextFileType(path)) {
+        //忽略非文本文件和不存在的文件
+        if (!QFile::exists(path) || !Utils::isTextFileType(path)) {
             continue;
         }
         m_custom_log_list.append(QStringList() << QFileInfo(iter).fileName() << path);
@@ -181,8 +181,8 @@ void LogApplicationHelper::initCustomLog()
         QString path = iter;
         if (path.startsWith("~/"))
             path.replace(0, 1, QDir::homePath());
-        //忽略非文本文件
-        if (!Utils::isTextFileType(path)) {
+        //忽略非文本文件和不存在的文件
+        if (!QFile::exists(path) || !Utils::isTextFileType(path)) {
             continue;
         }
         m_custom_log_list.append(QStringList() << QFileInfo(iter).fileName() << path);
@@ -256,7 +256,9 @@ void LogApplicationHelper::createDesktopFiles()
 
             if (lineStr.startsWith("NotShowIn")) {
                 QStringList notShowInList = lineStr.split("=", QString::SkipEmptyParts).value(1, "").split(";", QString::SkipEmptyParts);
-                if (std::any_of(notShowInList.begin(), notShowInList.end(), [currentDesktop](const auto & data) { return data == currentDesktop; })) {
+                if (std::any_of(notShowInList.begin(), notShowInList.end(), [currentDesktop](const auto & data) {
+                return data == currentDesktop;
+            })) {
                     canDisplay = false;
                 }
             }

--- a/application/utils.cpp
+++ b/application/utils.cpp
@@ -50,7 +50,7 @@ QString Utils::getQssContent(const QString &filePath)
 QString Utils::getConfigPath()
 {
     QDir dir(QDir(QStandardPaths::standardLocations(QStandardPaths::ConfigLocation).first())
-                 .filePath(qApp->organizationName()));
+             .filePath(qApp->organizationName()));
 
     return dir.filePath(qApp->applicationName());
 }
@@ -71,7 +71,8 @@ bool Utils::isTextFileType(const QString &filePath)
 {
     QMimeDatabase db;
     QMimeType mime = db.mimeTypeForFile(filePath);
-    if (mime.inherits("text/plain")) {
+    //标准文本文件和空白无后缀文件均计入文本文件范围
+    if (mime.inherits("text/plain") || mime.inherits("application/x-zerosize")) {
         return true;
     }
     return false;
@@ -271,7 +272,7 @@ QString Utils::osVersion()
     auto str = QString::fromUtf8(output);
     QRegExp re("\t.+\n");
     QString osVerStr;
-    if(re.indexIn(str) > -1) {
+    if (re.indexIn(str) > -1) {
         auto result = re.cap(0);
         osVerStr = result.remove(0, 1).remove(result.size() - 1, 1);
         qInfo() << "lsb_release -r:" << output;


### PR DESCRIPTION
原因是在过滤非文本文件的时候，将mime type为x-zerosize的空白无后缀文件也过滤掉了
解决方法是添加过滤白名单，同时进一步过滤掉不存在的文件

Log: 修复自定义日志无法监控空白无后缀文件
Bug: https://pms.uniontech.com/bug-view-183671.html