### PR TITLE
fix: 修复未安装帮助手册文件

### DIFF
--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -377,7 +377,7 @@ install(FILES gschema/com.deepin.log-viewer.gschema.xml
 # Install files
 install(TARGETS ${EXE_NAME} DESTINATION bin)
 install(DIRECTORY assets/deepin-log-viewer
-                DESTINATION /usr/share/deepin-manual/manual-assets/application/)
+                DESTINATION ${CMAKE_INSTALL_PREFIX}/share/deepin-manual/manual-assets/application/)
 
 #FILES       - deployed files.
 #BASE        - used to get subpath, if it's empty, only copy files, and ignore it's subpath structure.

--- a/debian/deepin-log-viewer.install
+++ b/debian/deepin-log-viewer.install
@@ -11,3 +11,4 @@ usr/share/glib-2.0/schemas/*.gschema.xml
 usr/share/deepin-log-viewer/translations/*.qm
 usr/share/polkit-1/actions/*.policy
 usr/share/icons/hicolor/scalable/apps/*.svg
+usr/share/deepin-manual


### PR DESCRIPTION
原因是之前添加了install文件控制安装的内容，但没有添加安装帮助手册
解决方法是将帮助手册文件添加上去

Log: 修复未安装帮助手册文件
Bug: https://pms.uniontech.com/bug-view-187497.html