### PR TITLE
fix: 修复获取内核日志读取卡住，展示空白的问题

### DIFF
--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -61,13 +61,16 @@ QString LogViewerService::readLog(const QString &filePath)
 
     //QByteArray -> QString 如果遇到0x00，会导致转换终止
     //replace("\x00", "")和replace("\u0000", "")无效
-    for(int i = 0;i != byte.size();++i) {
-        if(byte.at(i) == 0x00) {
-            byte.remove(i, 1);
-            i--;
+    //使用remove操作，性能损耗过大，因此遇到0x00 替换为 0x20(空格符)
+    qInfo() << "replace 0x00 to 0x20 begin";
+    int replaceTimes = 0;
+    for (int i = 0; i != byte.size(); ++i) {
+        if (byte.at(i) == 0x00) {
+            byte[i] = 0x20;
+            replaceTimes++;
         }
     }
-
+    qInfo() << "replace 0x00 to 0x20   end. replaceTimes:" << replaceTimes;
     return QString::fromUtf8(byte);
 }
 


### PR DESCRIPTION
  该内核日志为klv机器内核日志，大小为304.1MB，dbus服务将内容读取到QByteArray字节流数组中(3亿字节大小），其中包含2383处0x00非法字符字节。
  为了保证QByteArray转QString不被0x00截断，原有方案是直接从字节流数组剔除0x00，但频繁改变3亿数组的大小，会带来极大时间损耗，导致读取日志卡住，达到dbus超时时限，内核日志视图展示为空白内容。参见https://pms.uniontech.com/bug-view-147301.html
  因此本次修改方案为：将0x00替换为0x20(空格符)，以避免频繁改变数组大小带来的耗时开销。

Log: 修复获取内核日志读取卡住，展示空白的问题
Bug: https://pms.uniontech.com/bug-view-198137.html