### PR TITLE
chore: Update version to 6.0.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-log-viewer (6.0.8) unstable; urgency=medium
+
+  * fix: 修复获取内核日志读取卡住，展示空白的问题(Bug: 198137)
+
+ -- Deepin Packages Builder <packages@deepin.org>  Tue, 09 May 2023 17:39:35 +0800
+
 deepin-log-viewer (6.0.7) unstable; urgency=medium
 
   * Update version


### PR DESCRIPTION
  修复打开某些300MB内核日志卡住，并显示空白的问题
  相关PR:
  * https://github.com/linuxdeepin/deepin-log-viewer/pull/148

Log: Update version to 6.0.8