### PR TITLE
fix: 修复点击全部导出时，默认导出名称未按当前时间更新的问题

### DIFF
--- a/application/dbusproxy/dldbushandler.cpp
+++ b/application/dbusproxy/dldbushandler.cpp
@@ -30,9 +30,9 @@ DLDBusHandler::DLDBusHandler(QObject *parent)
                                           this);
     //Note: when dealing with remote objects, it is not always possible to determine if it exists when creating a QDBusInterface.
     if (!m_dbus->isValid() && !m_dbus->lastError().message().isEmpty()) {
-        qDebug() << "m_dbus isValid false error:" << m_dbus->lastError() << m_dbus->lastError().message();
+        qDebug() << "dbus com.deepin.logviewer isValid false error:" << m_dbus->lastError() << m_dbus->lastError().message();
     }
-    qDebug() << "m_dbus isValid true";
+    qDebug() << "dbus com.deepin.logviewer isValid true";
 }
 
 /*!

--- a/application/logallexportthread.cpp
+++ b/application/logallexportthread.cpp
@@ -41,7 +41,7 @@ void LogAllExportThread::run()
             data.logCategory = "kernel";
             data.commands.push_back("dmesg");
         } else if (it.contains(LAST_TREE_DATA, Qt::CaseInsensitive)) {
-            data.logCategory = "boot-shutdown event";
+            data.logCategory = "boot-shutdown-event";
             data.commands.push_back("last");
         } else if (it.contains(DPKG_TREE_DATA, Qt::CaseInsensitive)) {
             data.logCategory = "dpkg";

--- a/application/logapplicationhelper.cpp
+++ b/application/logapplicationhelper.cpp
@@ -218,7 +218,6 @@ void LogApplicationHelper::createDesktopFiles()
             }
         }
     }
-    qDebug() << "  tempDesktopFiles.count()" << tempDesktopFiles.count();
     for (QString var : tempDesktopFiles) {
         QString filePath = path + "/" + var;
         QFile fi(filePath);
@@ -291,7 +290,6 @@ void LogApplicationHelper::createDesktopFiles()
             parseField(filePath, var.split(QDir::separator()).last(), isDeepin, isGeneric, isName);
         }
     }
-    qDebug() << "  m_desktop_files.count()" << m_desktop_files.count();
 }
 
 /**
@@ -310,7 +308,6 @@ void LogApplicationHelper::createLogFiles()
     }
 
     m_log_files = appDir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot);
-    //qDebug() << " m_log_files.size()" << appDir.entryInfoList(QDir::AllEntries | QDir::NoDotAndDotDot | QDir::Hidden);
 
     for (auto i = 0; i < m_desktop_files.count(); ++i) {
         QString desktopName = m_desktop_files[i].split(QDir::separator()).last();

--- a/application/logbackend.cpp
+++ b/application/logbackend.cpp
@@ -67,7 +67,7 @@ void LogBackend::exportAllLogs(const QString &outDir)
 
     m_outPath = outPath;
 
-    static QString fileFullPath = outPath + "/" + QString("%1_%2_all_logs.zip").arg(dateTime).arg(hostname);
+    QString fileFullPath = outPath + "/" + QString("%1_%2_all_logs.zip").arg(dateTime).arg(hostname);
 
     // 添加文件后缀
     if (!fileFullPath.endsWith(".zip")) {

--- a/application/logcollectormain.cpp
+++ b/application/logcollectormain.cpp
@@ -306,7 +306,7 @@ void LogCollectorMain::exportAllLogs()
     QString hostname = QString(_utsname.nodename);
 
     static QString defaultDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
-    static QString fileFullPath = defaultDir + "/" + QString("%1_%2_all_logs.zip").arg(dateTime).arg(hostname);
+    QString fileFullPath = defaultDir + "/" + QString("%1_%2_all_logs.zip").arg(dateTime).arg(hostname);
     QString newPath = DFileDialog::getSaveFileName(this, "", fileFullPath, "*.zip");
     if (newPath.isEmpty()) {
         return;

--- a/application/utils.cpp
+++ b/application/utils.cpp
@@ -281,8 +281,6 @@ QString Utils::osVersion()
     if (re.indexIn(str) > -1) {
         auto result = re.cap(0);
         osVerStr = result.remove(0, 1).remove(result.size() - 1, 1);
-        qInfo() << "lsb_release -r:" << output;
-        qInfo() << "OS version:" << osVerStr;
     }
     unlock->deleteLater();
     return osVerStr;


### PR DESCRIPTION
  1.点击全部导出时，默认导出名称按当前时间更新
  2.导出目录二级目录开关机事件目录名称变更为boot-shutdown-event
  3.清除冗余日志

Log: 修复点击全部导出时，默认导出名称未按当前时间更新的问题