### PR TITLE
chore: Update version to 6.1.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+deepin-log-viewer (6.1.0) unstable; urgency=medium
+
+  * fix: modify audit rule
+  * feat: collect crash log(Task: 279017)
+  * fix: fix review problems
+  * feat: add command -e option(support export all)
+  * fix: cli run in the single instance
+  * feat: export all-add subdirectory
+  * chore: update Ts
+  * feat: export all-support export coredump files
+  * fix: cli run in the single instance
+  * fix: fix export name not update to current time
+  * feat: other logs add kwin logs
+  * fix: other log and custom log add search feature
+  * fix: fix 1042 build fail
+  * fix: fix kwin logs can't show content
+  * feat: xorg log column datetime change to offset
+  * fix: export all-directory other change to others
+
+ -- Deepin Packages Builder <packages@deepin.org>  Thu, 03 Aug 2023 16:36:26 +0800
+
 deepin-log-viewer (6.0.10) unstable; urgency=medium
 
   * Update version to 6.0.10


### PR DESCRIPTION
  1.修改审计筛选规则
  2.添加崩溃日志功能
  3.其他日志添加窗管日志
  4.支持用cli命令全部导出日志
  5.全部导出目录优化-日志种类按一二级目录划分

  相关PR:
    * linuxdeepin#161
    * linuxdeepin#162
    * linuxdeepin#166
    * linuxdeepin#167
    * linuxdeepin#168
    * linuxdeepin#170
    * linuxdeepin#174

Log: Update version to 6.1.0