### PR TITLE
fix: 修复崩溃日志显示不全的问题

### DIFF
--- a/application/logallexportthread.cpp
+++ b/application/logallexportthread.cpp
@@ -87,7 +87,7 @@ void LogAllExportThread::run()
                     data.files.append(paths);
             }
         } else if (it.contains(CUSTOM_TREE_DATA, Qt::CaseInsensitive)) {
-            data.logCategory = "custom";
+            data.logCategory = "customized";
             auto customLogListPair = LogApplicationHelper::instance()->getCustomLogList();
             for (auto &it2 : customLogListPair) {
                 data.files.append(it2.at(1));


### PR DESCRIPTION
  使用--no-pager参数获取全部崩溃日志，针对崩溃日志，使用finished信号获取命令行输出全部内容

Log: 修复崩溃日志显示不全的问题
Bug: https://pms.uniontech.com/bug-view-217023.html