### PR TITLE
chore: Update version to 6.1.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-log-viewer (6.1.1) unstable; urgency=medium
+
+  * fix: fix coredump logs show is not complete(Bug: 217023)
+  * fix: fix export coredump logs failed(Bug: 217019)
+  * feat: add accessible labels
+
+ -- Deepin Packages Builder <packages@deepin.org>  Thu, 31 Aug 2023 16:02:33 +0800
+
 deepin-log-viewer (6.1.0) unstable; urgency=medium
 
   * fix: modify audit rule


### PR DESCRIPTION
 1.修复崩溃日志显示不全的问题
 2.修复崩溃日志导出失败的问题
 3.添加accessible标签

 相关PR：
  * linuxdeepin#177
  * linuxdeepin#180
  * linuxdeepin#181

Log: Update version to 6.1.1