### PR TITLE
fix: Command line export initializes homePath first

### DIFF
--- a/application/main.cpp
+++ b/application/main.cpp
@@ -68,10 +68,10 @@ int main(int argc, char *argv[])
             if (!args.isEmpty())
                 outDir = args.first();
 
-            // 设置命令行工作目录
-            LogBackend::instance(&a)->setCmdWorkDir(argv[argc - 2]);
             // 根据当前用户名获取正确家目录路径
             Utils::homePath = Utils::getHomePath(argv[argc - 1]);
+            // 设置命令行工作目录
+            LogBackend::instance(&a)->setCmdWorkDir(argv[argc - 2]);
 
             // 全部导出日志
             LogBackend::instance(&a)->exportAllLogs(outDir);


### PR DESCRIPTION
  Command line export initializes homePath first

Log: Command line export initializes homePath first
Bug: https://pms.uniontech.com/bug-view-219629.html