### PR TITLE
fix: cli export -t&-d option cannot use together

### DIFF
--- a/application/main.cpp
+++ b/application/main.cpp
@@ -145,6 +145,11 @@ int main(int argc, char *argv[])
                 }
             }
 
+            if (!type.isEmpty() && type != "app" && !appName.isEmpty()) {
+                qCWarning(logAppMain) << QString("Option -d -t both exist, -t can only be set to 'app' type.");
+                return -1;
+            }
+
             if (!type.isEmpty()) {
                 // 按类型导出日志
                 if (period.isEmpty() &&


### PR DESCRIPTION
   cli export -t&-d option cannot use together, except for '-t app'

Log: cli export -t&-d option cannot use together
Bug: https://pms.uniontech.com/bug-view-226569.html