### PR TITLE
fix: Fix the issue of exporting the boot log as empty by level in cli

### DIFF
--- a/application/logbackend.cpp
+++ b/application/logbackend.cpp
@@ -1492,7 +1492,8 @@ void LogBackend::initParser()
             Qt::QueuedConnection);
     connect(m_pParser, &LogFileParser::normalFinished, this, &LogBackend::slot_normalFinished,
             Qt::QueuedConnection);
-    connect(m_pParser, &LogFileParser::journalBootFinished, this, &LogBackend::slot_journalBootFinished);
+    connect(m_pParser, &LogFileParser::journalBootFinished, this, &LogBackend::slot_journalBootFinished,
+            Qt::QueuedConnection);
 
     connect(m_pParser, &LogFileParser::proccessError, this, &LogBackend::slot_logLoadFailed,
             Qt::QueuedConnection);


### PR DESCRIPTION
  Fix the issue of exporting the boot log as empty by level in cli

Log: Fix the issue of exporting the boot log as empty by level in cli
Bug: https://pms.uniontech.com/bug-view-226673.html