### PR TITLE
fix: Coredump report time use is recorded by Dconfig/gsettings

### DIFF
--- a/application/configs/org.deepin.deepin-log-viewer.json
+++ b/application/configs/org.deepin.deepin-log-viewer.json
@@ -12,6 +12,16 @@
             "permissions": "readwrite",
             "visibility": "private"
         },
+	"coredumpReportTime": {
+            "value": "",
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Coredump report time",
+            "name[zh_CN]": "最近一次上报成功的崩溃信息时间点",
+            "description": "The time point of the last successful crash report",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
 	"specialComType": {
             "value": -1,
             "serial": 0,

--- a/application/gschema/com.deepin.log-viewer.gschema.xml
+++ b/application/gschema/com.deepin.log-viewer.gschema.xml
@@ -7,5 +7,11 @@
             <summary>Show extra logs</summary>
             <description>It is null by default. To display extra logs in Log Viewer, please configure the absolute path of the corresponding log file. And make sure the operator has permission to read it.For example: ['a.log', 'b.log', 'c.log']</description>
         </key>
+        <key type="s" name="coredumpreporttime">
+            <default>''
+	     </default>
+            <summary>Coredump report time</summary>
+            <description>It is null by default. Record the time point of the last successful crash report, used to achieve incremental escalation</description>
+        </key>
     </schema>
 </schemalist>

--- a/application/logapplicationhelper.cpp
+++ b/application/logapplicationhelper.cpp
@@ -12,6 +12,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QLoggingCategory>
+#include <QDateTime>
 
 #ifdef QT_DEBUG
 Q_LOGGING_CATEGORY(logAppHelper, "org.deepin.log.viewer.application.helper")
@@ -25,6 +26,8 @@ std::mutex LogApplicationHelper::m_mutex;
 // 自研应用日志json配置文件目录
 const QString APP_LOG_CONFIG_PATH = "/usr/share/deepin-log-viewer/deepin-log.conf.d";
 
+const QString COREDUMP_REPORT_TIME = "coredumpReportTime";
+const QString COREDUMP_REPORT_TIME_GSETTING = "coredumpreporttime";
 /**
  * @brief LogApplicationHelper::LogApplicationHelper 构造函数，获取日志文件路径和应用名称
  * @param parent 父对象
@@ -602,6 +605,37 @@ bool LogApplicationHelper::isValidAppName(const QString &appName)
         return true;
 
     return false;
+}
+
+QDateTime LogApplicationHelper::getLastReportTime()
+{
+    QVariant time;
+
+#ifdef DTKCORE_CLASS_DConfigFile
+    time = m_pDConfig->value(COREDUMP_REPORT_TIME);
+#else
+    if (m_pGSettings) {
+        time = m_pGSettings->get(COREDUMP_REPORT_TIME_GSETTING);
+    }
+#endif
+
+    if (time.isValid()) {
+        return QDateTime::fromString(time.toString(), "yyyy-MM-dd hh:mm:ss");
+    }
+
+    return QDateTime();
+}
+
+void LogApplicationHelper::saveLastRerportTime(const QDateTime &date)
+{
+    QString str = date.toString("yyyy-MM-dd hh:mm:ss");
+
+#ifdef DTKCORE_CLASS_DConfigFile
+    m_pDConfig->setValue(COREDUMP_REPORT_TIME, str);
+#else
+    if (m_pGSettings)
+        m_pGSettings->set(COREDUMP_REPORT_TIME_GSETTING, str);
+#endif
 }
 
 //从应用包名转换为应用显示文本

--- a/application/logapplicationhelper.h
+++ b/application/logapplicationhelper.h
@@ -62,6 +62,9 @@ public:
     // 验证是否为有效的应用名
     bool isValidAppName(const QString& appName);
 
+    QDateTime getLastReportTime();
+    void saveLastRerportTime(const QDateTime& date);
+
 private:
     explicit LogApplicationHelper(QObject *parent = nullptr);
 

--- a/application/logbackend.cpp
+++ b/application/logbackend.cpp
@@ -798,7 +798,7 @@ void LogBackend::slot_coredumpFinished(int index)
         int nCount = m_currentCoredumpList.size();
         if (nCount == 0) {
             qCWarning(logBackend) << QString("Report coredump info failed, timeRange: '%1 ---- %2', no matching data.")
-                                     .arg(LogSettings::instance()->getConfigLastReportTime().toString("yyyy-MM-dd hh:mm:ss"))
+                                     .arg(LogApplicationHelper::instance()->getLastReportTime().toString("yyyy-MM-dd hh:mm:ss"))
                                      .arg(QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss"));
             qApp->exit(-1);
         } else {
@@ -830,7 +830,7 @@ void LogBackend::slot_coredumpFinished(int index)
                 };
 
                 Eventlogutils::GetInstance()->writeLogs(objCoredumpEvent);
-                LogSettings::instance()->saveLastRerportTime(latestCoredumpTime);
+                LogApplicationHelper::instance()->saveLastRerportTime(latestCoredumpTime);
                 qCInfo(logBackend) << QString("Successfully reported %1 crash messages in total.").arg(m_currentCoredumpList.size());
                 qApp->exit(0);
             });
@@ -1674,7 +1674,7 @@ bool LogBackend::reportCoredumpInfo()
 
     // 增量上报，每次上报，仅上报新增的崩溃信息，根据时间范围筛选出目标数据
     COREDUMP_FILTERS coreFilter;
-    QDateTime lastTime = LogSettings::instance()->getConfigLastReportTime();
+    QDateTime lastTime = LogApplicationHelper::instance()->getLastReportTime();
     if (!lastTime.isValid()) {
         TIME_RANGE timeRange = getTimeRange(ALL);
         coreFilter.timeFilterBegin = timeRange.begin;

--- a/application/logsettings.cpp
+++ b/application/logsettings.cpp
@@ -12,7 +12,6 @@
 #include <QDateTime>
 #define MAINWINDOW_HEIGHT_NAME "logMainWindowHeightName"
 #define MAINWINDOW_WIDTH_NAME "logMainWindowWidthName"
-#define LAST_REPORT_TIME_NAME "lastReportTimeName"
 
 std::atomic<LogSettings *> LogSettings::m_instance;
 std::mutex LogSettings::m_mutex;
@@ -41,8 +40,6 @@ LogSettings::LogSettings(QObject *parent)
 
     m_logDirPath = infoPath.filePath("logdir-config.conf");
     m_logDirConfig = new QSettings(m_logDirPath, QSettings::IniFormat, this);
-
-
 }
 
 /**
@@ -83,23 +80,6 @@ void LogSettings::saveConfigWinSize(int w, int h)
     m_winInfoConfig->sync();
 }
 
-QDateTime LogSettings::getConfigLastReportTime()
-{
-    QVariant time = m_winInfoConfig->value(LAST_REPORT_TIME_NAME);
-    if (time.isValid()) {
-        return QDateTime::fromString(time.toString(), "yyyy-MM-dd hh:mm:ss");
-    }
-
-    return QDateTime();
-}
-
-void LogSettings::saveLastRerportTime(const QDateTime &date)
-{
-    QString str = date.toString("yyyy-MM-dd hh:mm:ss");
-    m_winInfoConfig->setValue(LAST_REPORT_TIME_NAME, str);
-    m_winInfoConfig->sync();
-}
-
 QMap<QString, QStringList> LogSettings::loadAuditMap()
 {
     QMap<QString, QStringList> auditType2EventType;
@@ -113,5 +93,3 @@ QMap<QString, QStringList> LogSettings::loadAuditMap()
 
     return auditType2EventType;
 }
-
-

--- a/application/logsettings.h
+++ b/application/logsettings.h
@@ -56,8 +56,6 @@ public:
     QString m_logDirPath;
     QSize getConfigWinSize();
     void saveConfigWinSize(int w, int h);
-    QDateTime getConfigLastReportTime();
-    void saveLastRerportTime(const QDateTime& date);
     void saveLogDir(const QString &iKey, const QString &iDir);
     QString getLogDir(const QString &iKey);
 


### PR DESCRIPTION
  Coredump report time use is recorded by Dconfig/gsettings

Log: Coredump report time use is recorded by Dconfig/gsettings
Bug: https://pms.uniontech.com/bug-view-227219.html