### PR TITLE
fix: coredump map info only parsed in report coredump

### DIFF
--- a/application/logauththread.cpp
+++ b/application/logauththread.cpp
@@ -1232,21 +1232,23 @@ void LogAuthThread::handleCoredump()
             coredumpMsg.storagePath = re.cap(0).replace("Storage: ", "");
             
             // get maps info
-            const QString &corePath =  QDir::homePath() + QString("/%1.dump").arg(QFileInfo(coredumpMsg.storagePath).fileName());
-            if (Utils::runInCmd) {
-                DLDBusHandler::instance()->readLog(QString("coredumpctl dump %1 -o %2").arg(coredumpMsg.pid).arg(corePath));
-                outInfoByte = DLDBusHandler::instance()->readLog(QString("readelf -n %1").arg(corePath));
-            } else {
-                m_process->start("pkexec", QStringList() << "logViewerAuth" << QStringList() << "coredumpctl-dump"
-                                 << coredumpMsg.pid << corePath << SharedMemoryManager::instance()->getRunnableKey());
-                m_process->waitForFinished(-1);
-                m_process->start("pkexec", QStringList() << "logViewerAuth" << QStringList() << "readelf"
-                                 << corePath << SharedMemoryManager::instance()->getRunnableKey());
-                m_process->waitForFinished(-1);
-                outInfoByte = m_process->readAllStandardOutput();
+            if (m_parseMap) {
+                const QString &corePath =  QDir::homePath() + QString("/%1.dump").arg(QFileInfo(coredumpMsg.storagePath).fileName());
+                if (Utils::runInCmd) {
+                    DLDBusHandler::instance()->readLog(QString("coredumpctl dump %1 -o %2").arg(coredumpMsg.pid).arg(corePath));
+                    outInfoByte = DLDBusHandler::instance()->readLog(QString("readelf -n %1").arg(corePath));
+                } else {
+                    m_process->start("pkexec", QStringList() << "logViewerAuth" << QStringList() << "coredumpctl-dump"
+                                     << coredumpMsg.pid << corePath << SharedMemoryManager::instance()->getRunnableKey());
+                    m_process->waitForFinished(-1);
+                    m_process->start("pkexec", QStringList() << "logViewerAuth" << QStringList() << "readelf"
+                                     << corePath << SharedMemoryManager::instance()->getRunnableKey());
+                    m_process->waitForFinished(-1);
+                    outInfoByte = m_process->readAllStandardOutput();
+                }
+                coredumpMsg.maps = outInfoByte;
+                QFile::remove(corePath);
             }
-            coredumpMsg.maps = outInfoByte;
-            QFile::remove(corePath);
         } else {
             coredumpMsg.storagePath = QString("coredump file is missing");
         }

--- a/application/logauththread.h
+++ b/application/logauththread.h
@@ -39,6 +39,7 @@ public:
     QString getStandardOutput();
     QString getStandardError();
     void setType(LOG_FLAG flag) { m_type = flag; }
+    void setParseMap(bool parseMap) { m_parseMap = parseMap; }
     void setFileterParam(const KWIN_FILTERS &iFIlters) { m_kwinFilters = iFIlters; }
     void setFileterParam(const XORG_FILTERS &iFIlters) { m_xorgFilters = iFIlters; }
     void setFileterParam(const DKPG_FILTERS &iFIlters) { m_dkpgFilters = iFIlters; }
@@ -158,6 +159,7 @@ private:
     /**
      * @brief m_threadIndex 当前线程标号
      */
+    bool m_parseMap = false; // 崩溃信息是否要解析map信息，即stackinfo
     int m_threadCount;
     //正在执行停止进程的变量，防止重复执行停止逻辑
     bool m_isStopProccess = false;

--- a/application/logbackend.cpp
+++ b/application/logbackend.cpp
@@ -1687,7 +1687,7 @@ bool LogBackend::reportCoredumpInfo()
     if (!m_pParser)
         initParser();
 
-    m_coredumpCurrentIndex = m_pParser->parseByCoredump(coreFilter);
+    m_coredumpCurrentIndex = m_pParser->parseByCoredump(coreFilter, true);
 
     return true;
 }

--- a/application/logfileparser.cpp
+++ b/application/logfileparser.cpp
@@ -451,13 +451,14 @@ int LogFileParser::parseByAudit(const AUDIT_FILTERS &iAuditFilter)
     return index;
 }
 
-int LogFileParser::parseByCoredump(const COREDUMP_FILTERS &iCoredumpFilter)
+int LogFileParser::parseByCoredump(const COREDUMP_FILTERS &iCoredumpFilter, bool parseMap)
 {
     stopAllLoad();
     m_isCoredumpLoading = true;
     //qRegisterMetaType<QList<quint16>>("QList<LOG_MSG_COREDUMP>");
     LogAuthThread   *authThread = new LogAuthThread(this);
     authThread->setType(COREDUMP);
+    authThread->setParseMap(parseMap);
     authThread->setFileterParam(iCoredumpFilter);
     connect(authThread, &LogAuthThread::coredumpFinished, this,
             &LogFileParser::coredumpFinished);

--- a/application/logfileparser.h
+++ b/application/logfileparser.h
@@ -47,7 +47,7 @@ public:
 
     int parseByAudit(const AUDIT_FILTERS &iAuditFilter);
 
-    int parseByCoredump(const COREDUMP_FILTERS &iCoredumpFilter);
+    int parseByCoredump(const COREDUMP_FILTERS &iCoredumpFilter, bool parseMap = false);
 
     void createFile(const QString &output, int count);
     void stopAllLoad();


### PR DESCRIPTION
  coredump map info only parsed in report coredump

Log: coredump map info only parsed in report coredump
Bug: https://pms.uniontech.com/bug-view-233653.html