### PR TITLE
fix: Fix security vulnerabilities introduced by LD_PRELOAD 2nd

### DIFF
--- a/application/dbusproxy/dldbushandler.cpp
+++ b/application/dbusproxy/dldbushandler.cpp
@@ -62,6 +62,11 @@ QString DLDBusHandler::readLogInStream(const QString &token)
     return m_dbus->readLogInStream(token);
 }
 
+QStringList DLDBusHandler::whiteListOutPaths()
+{
+    return m_dbus->whiteListOutPaths();
+}
+
 /*!
  * \~chinese \brief DLDBusHandler::exitCode 返回进程状态
  * \~chinese \return 进程返回值

--- a/application/dbusproxy/dldbushandler.h
+++ b/application/dbusproxy/dldbushandler.h
@@ -24,6 +24,7 @@ public:
     quint64 getFileSize(const QString &filePath);
     QString openLogStream(const QString &filePath);
     QString readLogInStream(const QString &token);
+    QStringList whiteListOutPaths();
 
 private:
     explicit DLDBusHandler(QObject *parent = nullptr);

--- a/application/dbusproxy/dldbusinterface.h
+++ b/application/dbusproxy/dldbusinterface.h
@@ -105,6 +105,12 @@ public Q_SLOTS: // METHODS
         argumentList << QVariant::fromValue(filePath);
         return asyncCallWithArgumentList(QStringLiteral("getFileSize"), argumentList);
     }
+
+    inline QDBusPendingReply<QStringList> whiteListOutPaths()
+    {
+        QList<QVariant> argumentList;
+        return asyncCallWithArgumentList(QStringLiteral("whiteListOutPaths"), argumentList);
+    }
 Q_SIGNALS: // SIGNALS
 };
 

--- a/application/logcollectormain.cpp
+++ b/application/logcollectormain.cpp
@@ -17,6 +17,7 @@
 #include <DTitlebar>
 #include <DWindowOptionButton>
 #include <DWindowCloseButton>
+#include <DMessageManager>
 
 #include <QDateTime>
 #include <QDebug>
@@ -317,6 +318,17 @@ void LogCollectorMain::exportAllLogs()
     if (newPath.isEmpty()) {
         return;
     }
+
+    // 导出路径白名单检查
+    QFileInfo info(newPath);
+    QString outPath = info.path();
+    QStringList availablePaths =  DLDBusHandler::instance(this)->whiteListOutPaths();
+    if (!availablePaths.contains(outPath)) {
+        QString titleIcon = ICONPREFIX;
+        DMessageManager::instance()->sendMessage(this->window(), QIcon(titleIcon + "warning_info.svg"), DApplication::translate("ExportMessage", "The export directory is not available. Please choose another directory for the export operation."));
+        return;
+    }
+
     //添加文件后缀
     if (!newPath.endsWith(".zip")) {
         newPath += ".zip";

--- a/application/main.cpp
+++ b/application/main.cpp
@@ -36,12 +36,6 @@ Q_LOGGING_CATEGORY(logAppMain, "org.deepin.log.viewer.main", QtInfoMsg)
 
 int main(int argc, char *argv[])
 {
-    // 检查是否开启预加载，防止黑客利用预加载的so库劫持日志后端服务干坏事
-    if (getenv("LD_PRELOAD")) {
-        qCritical() << "env LP_PRELOAD is illegal, please unset it.";
-        return -1;
-    }
-
     //在root下或者非deepin/uos环境下运行不会发生异常，需要加上XDG_CURRENT_DESKTOP=Deepin环境变量；
     if (!QString(qgetenv("XDG_CURRENT_DESKTOP")).toLower().startsWith("deepin")) {
         setenv("XDG_CURRENT_DESKTOP", "Deepin", 1);
@@ -168,6 +162,14 @@ int main(int argc, char *argv[])
             QString outDir = cmdParser.value(exportOption);
             if (outDir.isEmpty()) {
                 qCWarning(logAppMain) << "plseae input outpath.";
+                return -1;
+            }
+
+            // 导出路径白名单检查
+            QStringList availablePaths =  DLDBusHandler::instance(&a)->whiteListOutPaths();
+            if (!availablePaths.contains(outDir)) {
+                QString titleIcon = ICONPREFIX;
+                qCWarning(logAppMain) << qApp->translate("ExportMessage", "The export directory is not available. Please choose another directory for the export operation.");
                 return -1;
             }
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: deepin-log-viewer
 Section: utils
 Priority: optional
 Maintainer: Deepin Packages Builder <packages@deepin.org>
-Build-Depends: debhelper (>= 11),cmake, pkg-config, qtbase5-dev, qtchooser (>= 55-gc9562a1-1~),qt5-qmake, libdtkwidget-dev, libdtkgui-dev, qttools5-dev-tools, libqt5svg5-dev, libsystemd-dev, libicu-dev, qttools5-dev, libdframeworkdbus-dev, libgtest-dev, libgmock-dev, libkf5codecs-dev, libzip-dev, libxerces-c-dev, libboost-dev, libminizip-dev, rapidjson-dev, libltdl-dev, libpolkit-qt5-1-dev, libgsettings-qt-dev
+Build-Depends: debhelper (>= 11),cmake, pkg-config, qtbase5-dev, qtchooser (>= 55-gc9562a1-1~),qt5-qmake, libdtkwidget-dev, libdtkgui-dev, qttools5-dev-tools, libqt5svg5-dev, libsystemd-dev, libicu-dev, qttools5-dev, libdframeworkdbus-dev, libgtest-dev, libgmock-dev, libkf5codecs-dev, libzip-dev, libxerces-c-dev, libboost-dev, libminizip-dev, rapidjson-dev, libltdl-dev, libpolkit-qt5-1-dev, libgsettings-qt-dev, libgio-qt-dev
 Standards-Version: 4.1.3
 
 Package: deepin-log-viewer

--- a/logViewerService/CMakeLists.txt
+++ b/logViewerService/CMakeLists.txt
@@ -39,6 +39,9 @@ find_package(Qt5 COMPONENTS
     Widgets
     DBus
 REQUIRED)
+pkg_check_modules(3rd_lib REQUIRED
+         gio-qt
+        )
 
 set(LINK_LIBS
     Qt5::Core
@@ -54,6 +57,7 @@ add_executable(${PROJECT_NAME} ${ALL_SOURCES} ${ALL_HEADERS})
 target_include_directories(${PROJECT_NAME} PUBLIC
     ${Qt5Gui_PRIVATE_INCLUDE_DIRS}
     ${PROJECT_BINARY_DIR}
+    ${3rd_lib_INCLUDE_DIRS}
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${DtkWidget_INCLUDE_DIRS} ${OBJECT_BINARY_DIR})
@@ -61,6 +65,7 @@ target_link_libraries(${PROJECT_NAME}
     ${LINK_LIBS}
     ${DtkWidget_LIBRARIES}
     ${Qt5Widgets_LIBRARIES}
+    ${3rd_lib_LIBRARIES}
 )
 set(CMAKE_INSTALL_PREFIX /usr)
 

--- a/logViewerService/assets/data/com.deepin.logviewer.xml
+++ b/logViewerService/assets/data/com.deepin.logviewer.xml
@@ -37,5 +37,8 @@
       <arg type="t" direction="out"/>
       <arg name="filePath" type="s" direction="in"/>
     </method>
+    <method name="whiteListOutPaths">
+      <arg type="as" direction="out"/>
+    </method>
   </interface>
 </node>

--- a/logViewerService/logviewerservice.h
+++ b/logViewerService/logviewerservice.h
@@ -5,6 +5,8 @@
 #ifndef LOGVIEWERSERVICE_H
 #define LOGVIEWERSERVICE_H
 
+#include <dgiomount.h>
+
 #include <QObject>
 #include <QDBusContext>
 #include <QScopedPointer>
@@ -12,7 +14,7 @@
 #include <QTemporaryDir>
 
 class QTextStream;
-
+class DGioVolumeManager;
 class LogViewerService : public QObject
     , protected QDBusContext
 {
@@ -35,7 +37,14 @@ public Q_SLOTS:
     Q_SCRIPTABLE QString readLogInStream(const QString &token);
     Q_SCRIPTABLE bool isFileExist(const QString &filePath);
     Q_SCRIPTABLE quint64 getFileSize(const QString &filePath);
+    Q_SCRIPTABLE QStringList whiteListOutPaths();
 
+private:
+    // 获取应用当前登录用户家目录
+    QString getAppUserHomePath();
+    //获取外设挂载路径(包括smb路径)
+    QStringList getExternalDevPaths();
+    QList<QExplicitlySharedDataPointer<DGioMount>> getMounts_safe();
 private:
     QTemporaryDir tmpDir;
     QProcess m_process;

--- a/translations/deepin-log-viewer.ts
+++ b/translations/deepin-log-viewer.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Export failed</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>

--- a/translations/deepin-log-viewer_ady.ts
+++ b/translations/deepin-log-viewer_ady.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_af.ts
+++ b/translations/deepin-log-viewer_af.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ak.ts
+++ b/translations/deepin-log-viewer_ak.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_am_ET.ts
+++ b/translations/deepin-log-viewer_am_ET.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ar.ts
+++ b/translations/deepin-log-viewer_ar.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ast.ts
+++ b/translations/deepin-log-viewer_ast.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_az.ts
+++ b/translations/deepin-log-viewer_az.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>İxrac baş tutmadı</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_bg.ts
+++ b/translations/deepin-log-viewer_bg.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_bn.ts
+++ b/translations/deepin-log-viewer_bn.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_bo.ts
+++ b/translations/deepin-log-viewer_bo.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>འདོན་མི་ཐུབ།</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_bqi.ts
+++ b/translations/deepin-log-viewer_bqi.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_br.ts
+++ b/translations/deepin-log-viewer_br.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ca.ts
+++ b/translations/deepin-log-viewer_ca.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Ha fallat l&apos;exportació.</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_cs.ts
+++ b/translations/deepin-log-viewer_cs.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Export se nezdařil</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_da.ts
+++ b/translations/deepin-log-viewer_da.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_de.ts
+++ b/translations/deepin-log-viewer_de.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Exportieren fehlgeschlagen</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_el.ts
+++ b/translations/deepin-log-viewer_el.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_en_AU.ts
+++ b/translations/deepin-log-viewer_en_AU.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_en_CA.ts
+++ b/translations/deepin-log-viewer_en_CA.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_en_GB.ts
+++ b/translations/deepin-log-viewer_en_GB.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_eo.ts
+++ b/translations/deepin-log-viewer_eo.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_es.ts
+++ b/translations/deepin-log-viewer_es.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Exportar fallós</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_et.ts
+++ b/translations/deepin-log-viewer_et.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_fa.ts
+++ b/translations/deepin-log-viewer_fa.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_fi.ts
+++ b/translations/deepin-log-viewer_fi.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Vienti epäonnistui</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_fil.ts
+++ b/translations/deepin-log-viewer_fil.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_fr.ts
+++ b/translations/deepin-log-viewer_fr.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Exportation échouée</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_gl_ES.ts
+++ b/translations/deepin-log-viewer_gl_ES.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_he.ts
+++ b/translations/deepin-log-viewer_he.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_hi_IN.ts
+++ b/translations/deepin-log-viewer_hi_IN.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>निर्यात विफल</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_hr.ts
+++ b/translations/deepin-log-viewer_hr.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_hu.ts
+++ b/translations/deepin-log-viewer_hu.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Az exportálás sikertelen</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_hy.ts
+++ b/translations/deepin-log-viewer_hy.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ia.ts
+++ b/translations/deepin-log-viewer_ia.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_id.ts
+++ b/translations/deepin-log-viewer_id.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_it.ts
+++ b/translations/deepin-log-viewer_it.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Esportazione fallita</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -498,11 +502,71 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ja.ts
+++ b/translations/deepin-log-viewer_ja.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ka.ts
+++ b/translations/deepin-log-viewer_ka.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_km_KH.ts
+++ b/translations/deepin-log-viewer_km_KH.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_kn_IN.ts
+++ b/translations/deepin-log-viewer_kn_IN.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ko.ts
+++ b/translations/deepin-log-viewer_ko.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ku.ts
+++ b/translations/deepin-log-viewer_ku.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ku_IQ.ts
+++ b/translations/deepin-log-viewer_ku_IQ.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ky.ts
+++ b/translations/deepin-log-viewer_ky.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ky@Arab.ts
+++ b/translations/deepin-log-viewer_ky@Arab.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_la.ts
+++ b/translations/deepin-log-viewer_la.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_lo.ts
+++ b/translations/deepin-log-viewer_lo.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_lt.ts
+++ b/translations/deepin-log-viewer_lt.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_lv.ts
+++ b/translations/deepin-log-viewer_lv.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ml.ts
+++ b/translations/deepin-log-viewer_ml.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_mn.ts
+++ b/translations/deepin-log-viewer_mn.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_mr.ts
+++ b/translations/deepin-log-viewer_mr.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ms.ts
+++ b/translations/deepin-log-viewer_ms.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Eksport gagal</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_nb.ts
+++ b/translations/deepin-log-viewer_nb.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ne.ts
+++ b/translations/deepin-log-viewer_ne.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_nl.ts
+++ b/translations/deepin-log-viewer_nl.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Het exporteren is mislukt</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_pa.ts
+++ b/translations/deepin-log-viewer_pa.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_pam.ts
+++ b/translations/deepin-log-viewer_pam.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_pl.ts
+++ b/translations/deepin-log-viewer_pl.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Błąd eksportu</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_pt.ts
+++ b/translations/deepin-log-viewer_pt.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Falha ao exportar</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_pt_BR.ts
+++ b/translations/deepin-log-viewer_pt_BR.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>A exportação falhou</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ro.ts
+++ b/translations/deepin-log-viewer_ro.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ru.ts
+++ b/translations/deepin-log-viewer_ru.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Ошибка экспорта</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_sc.ts
+++ b/translations/deepin-log-viewer_sc.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_si.ts
+++ b/translations/deepin-log-viewer_si.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_sk.ts
+++ b/translations/deepin-log-viewer_sk.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_sl.ts
+++ b/translations/deepin-log-viewer_sl.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Izvažanje ni uspelo</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_sq.ts
+++ b/translations/deepin-log-viewer_sq.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Eksportimi dështoi</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_sr.ts
+++ b/translations/deepin-log-viewer_sr.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Неуспешан извоз</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_sv.ts
+++ b/translations/deepin-log-viewer_sv.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_sw.ts
+++ b/translations/deepin-log-viewer_sw.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ta.ts
+++ b/translations/deepin-log-viewer_ta.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_th.ts
+++ b/translations/deepin-log-viewer_th.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_tr.ts
+++ b/translations/deepin-log-viewer_tr.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Dışa aktarılamadı</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ug.ts
+++ b/translations/deepin-log-viewer_ug.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>ھۆججەتننى چىقىرالمىدى</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_uk.ts
+++ b/translations/deepin-log-viewer_uk.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>Не вдалося експортувати</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_ur.ts
+++ b/translations/deepin-log-viewer_ur.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_uz.ts
+++ b/translations/deepin-log-viewer_uz.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_vi.ts
+++ b/translations/deepin-log-viewer_vi.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_zh_CN.ts
+++ b/translations/deepin-log-viewer_zh_CN.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>导出失败</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation>导出目录不可用，请选择其他目录进行导出操作。</translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -498,12 +502,72 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
-        <translation>导出日志</translation>
+        <source>Export logs to the specified path</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
-        <translation>指定日志导出目录。若未设置此项，默认导出到~/文档。</translation>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-log-viewer_zh_HK.ts
+++ b/translations/deepin-log-viewer_zh_HK.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>導出失敗</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-log-viewer_zh_TW.ts
+++ b/translations/deepin-log-viewer_zh_TW.ts
@@ -175,6 +175,10 @@
         <source>Export failed</source>
         <translation>匯出失敗</translation>
     </message>
+    <message>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File</name>
@@ -497,11 +501,71 @@
 <context>
     <name>main</name>
     <message>
-        <source>export logs</source>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin_log_viewer.ts
+++ b/translations/deepin_log_viewer.ts
@@ -4,34 +4,34 @@
 <context>
     <name>Action</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3956"/>
-        <location filename="../application/loglistview.cpp" line="448"/>
+        <location filename="../application/displaycontent.cpp" line="166"/>
+        <location filename="../application/loglistview.cpp" line="433"/>
         <source>Display in file manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="449"/>
+        <location filename="../application/loglistview.cpp" line="434"/>
         <source>Clear log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3957"/>
-        <location filename="../application/loglistview.cpp" line="450"/>
+        <location filename="../application/displaycontent.cpp" line="167"/>
+        <location filename="../application/loglistview.cpp" line="435"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="497"/>
+        <location filename="../application/loglistview.cpp" line="482"/>
         <source>Are you sure you want to clear the log?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="498"/>
+        <location filename="../application/loglistview.cpp" line="483"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="499"/>
+        <location filename="../application/loglistview.cpp" line="484"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -41,52 +41,52 @@
     <message>
         <location filename="../application/filtercontent.cpp" line="67"/>
         <location filename="../application/filtercontent.cpp" line="68"/>
-        <location filename="../application/filtercontent.cpp" line="575"/>
+        <location filename="../application/filtercontent.cpp" line="576"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../application/filtercontent.cpp" line="70"/>
         <location filename="../application/filtercontent.cpp" line="71"/>
-        <location filename="../application/filtercontent.cpp" line="568"/>
-        <location filename="../application/filtercontent.cpp" line="576"/>
+        <location filename="../application/filtercontent.cpp" line="569"/>
+        <location filename="../application/filtercontent.cpp" line="577"/>
         <source>Today</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../application/filtercontent.cpp" line="73"/>
         <location filename="../application/filtercontent.cpp" line="74"/>
-        <location filename="../application/filtercontent.cpp" line="569"/>
-        <location filename="../application/filtercontent.cpp" line="577"/>
+        <location filename="../application/filtercontent.cpp" line="570"/>
+        <location filename="../application/filtercontent.cpp" line="578"/>
         <source>3 days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../application/filtercontent.cpp" line="76"/>
         <location filename="../application/filtercontent.cpp" line="77"/>
-        <location filename="../application/filtercontent.cpp" line="570"/>
-        <location filename="../application/filtercontent.cpp" line="578"/>
+        <location filename="../application/filtercontent.cpp" line="571"/>
+        <location filename="../application/filtercontent.cpp" line="579"/>
         <source>1 week</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../application/filtercontent.cpp" line="79"/>
         <location filename="../application/filtercontent.cpp" line="80"/>
-        <location filename="../application/filtercontent.cpp" line="571"/>
-        <location filename="../application/filtercontent.cpp" line="579"/>
+        <location filename="../application/filtercontent.cpp" line="572"/>
+        <location filename="../application/filtercontent.cpp" line="580"/>
         <source>1 month</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../application/filtercontent.cpp" line="82"/>
         <location filename="../application/filtercontent.cpp" line="83"/>
-        <location filename="../application/filtercontent.cpp" line="572"/>
-        <location filename="../application/filtercontent.cpp" line="580"/>
+        <location filename="../application/filtercontent.cpp" line="573"/>
+        <location filename="../application/filtercontent.cpp" line="581"/>
         <source>3 months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="200"/>
+        <location filename="../application/filtercontent.cpp" line="201"/>
         <source>Export</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -95,112 +95,112 @@
 <context>
     <name>ComboBox</name>
     <message>
-        <location filename="../application/filtercontent.cpp" line="111"/>
-        <location filename="../application/filtercontent.cpp" line="130"/>
+        <location filename="../application/filtercontent.cpp" line="107"/>
+        <location filename="../application/filtercontent.cpp" line="128"/>
         <location filename="../application/filtercontent.cpp" line="159"/>
-        <location filename="../application/filtercontent.cpp" line="172"/>
-        <location filename="../application/filtercontent.cpp" line="187"/>
+        <location filename="../application/filtercontent.cpp" line="173"/>
+        <location filename="../application/filtercontent.cpp" line="188"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="112"/>
+        <location filename="../application/filtercontent.cpp" line="108"/>
         <source>Emergency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="113"/>
+        <location filename="../application/filtercontent.cpp" line="109"/>
         <source>Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="114"/>
-        <location filename="../application/filtercontent.cpp" line="132"/>
+        <location filename="../application/filtercontent.cpp" line="110"/>
+        <location filename="../application/filtercontent.cpp" line="130"/>
         <source>Critical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="115"/>
-        <location filename="../application/filtercontent.cpp" line="133"/>
+        <location filename="../application/filtercontent.cpp" line="111"/>
+        <location filename="../application/filtercontent.cpp" line="131"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="116"/>
-        <location filename="../application/filtercontent.cpp" line="134"/>
+        <location filename="../application/filtercontent.cpp" line="112"/>
+        <location filename="../application/filtercontent.cpp" line="132"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="117"/>
+        <location filename="../application/filtercontent.cpp" line="113"/>
         <source>Notice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="118"/>
-        <location filename="../application/filtercontent.cpp" line="120"/>
-        <location filename="../application/filtercontent.cpp" line="135"/>
+        <location filename="../application/filtercontent.cpp" line="114"/>
+        <location filename="../application/filtercontent.cpp" line="116"/>
+        <location filename="../application/filtercontent.cpp" line="133"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="119"/>
-        <location filename="../application/filtercontent.cpp" line="136"/>
+        <location filename="../application/filtercontent.cpp" line="115"/>
+        <location filename="../application/filtercontent.cpp" line="134"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="131"/>
+        <location filename="../application/filtercontent.cpp" line="129"/>
         <source>Super critical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="137"/>
+        <location filename="../application/filtercontent.cpp" line="135"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="173"/>
+        <location filename="../application/filtercontent.cpp" line="174"/>
         <source>Login</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="174"/>
+        <location filename="../application/filtercontent.cpp" line="175"/>
         <source>Boot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="175"/>
+        <location filename="../application/filtercontent.cpp" line="176"/>
         <source>Shutdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="188"/>
+        <location filename="../application/filtercontent.cpp" line="189"/>
         <source>Identity authentication</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="189"/>
+        <location filename="../application/filtercontent.cpp" line="190"/>
         <source>Discretionary Access Control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="190"/>
+        <location filename="../application/filtercontent.cpp" line="191"/>
         <source>Mandatory access control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="191"/>
+        <location filename="../application/filtercontent.cpp" line="192"/>
         <source>Remote</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="192"/>
+        <location filename="../application/filtercontent.cpp" line="193"/>
         <source>Document audit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="193"/>
+        <location filename="../application/filtercontent.cpp" line="194"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -208,12 +208,12 @@
 <context>
     <name>DisplayContent</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="1643"/>
+        <location filename="../application/displaycontent.cpp" line="1647"/>
         <source>TEXT (*.txt);; Doc (*.doc);; Xls (*.xls);; Html (*.html))</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="1649"/>
+        <location filename="../application/displaycontent.cpp" line="1653"/>
         <source>zip(*.zip)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -234,21 +234,27 @@
 <context>
     <name>ExportMessage</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3203"/>
+        <location filename="../application/displaycontent.cpp" line="3229"/>
         <source>Export successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3206"/>
+        <location filename="../application/displaycontent.cpp" line="3232"/>
         <source>Export failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/logcollectormain.cpp" line="328"/>
+        <location filename="../application/main.cpp" line="171"/>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>File</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="1641"/>
-        <location filename="../application/displaycontent.cpp" line="1647"/>
+        <location filename="../application/displaycontent.cpp" line="1645"/>
+        <location filename="../application/displaycontent.cpp" line="1651"/>
         <source>Export File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -257,24 +263,26 @@
     <name>Label</name>
     <message>
         <location filename="../application/filtercontent.cpp" line="63"/>
-        <location filename="../application/filtercontent.cpp" line="567"/>
-        <location filename="../application/filtercontent.cpp" line="574"/>
+        <location filename="../application/filtercontent.cpp" line="568"/>
+        <location filename="../application/filtercontent.cpp" line="575"/>
         <source>Period:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="107"/>
-        <location filename="../application/filtercontent.cpp" line="126"/>
+        <location filename="../application/filtercontent.cpp" line="101"/>
+        <location filename="../application/filtercontent.cpp" line="102"/>
+        <location filename="../application/filtercontent.cpp" line="122"/>
+        <location filename="../application/filtercontent.cpp" line="123"/>
         <source>Level:  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="144"/>
+        <location filename="../application/filtercontent.cpp" line="142"/>
         <source>Application list:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="155"/>
+        <location filename="../application/filtercontent.cpp" line="154"/>
         <location filename="../application/logdetailinfowidget.cpp" line="156"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
@@ -286,7 +294,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="183"/>
+        <location filename="../application/filtercontent.cpp" line="184"/>
         <source>Audit Type:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,14 +337,15 @@
 <context>
     <name>Level</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="161"/>
-        <location filename="../application/displaycontent.cpp" line="172"/>
-        <location filename="../application/displaycontent.cpp" line="183"/>
-        <location filename="../application/journalbootwork.cpp" line="418"/>
-        <location filename="../application/journalwork.cpp" line="368"/>
-        <location filename="../application/logauththread.cpp" line="75"/>
-        <location filename="../application/logauththread.cpp" line="88"/>
-        <location filename="../application/logexportthread.cpp" line="3418"/>
+        <location filename="../application/displaycontent.cpp" line="179"/>
+        <location filename="../application/displaycontent.cpp" line="190"/>
+        <location filename="../application/displaycontent.cpp" line="201"/>
+        <location filename="../application/journalappwork.cpp" line="298"/>
+        <location filename="../application/journalbootwork.cpp" line="377"/>
+        <location filename="../application/journalwork.cpp" line="339"/>
+        <location filename="../application/logauththread.cpp" line="80"/>
+        <location filename="../application/logauththread.cpp" line="93"/>
+        <location filename="../application/logexportthread.cpp" line="3424"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="850"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="859"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="2980"/>
@@ -348,16 +357,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="162"/>
-        <location filename="../application/displaycontent.cpp" line="175"/>
-        <location filename="../application/displaycontent.cpp" line="181"/>
-        <location filename="../application/journalbootwork.cpp" line="421"/>
-        <location filename="../application/journalwork.cpp" line="371"/>
-        <location filename="../application/logauththread.cpp" line="71"/>
-        <location filename="../application/logauththread.cpp" line="72"/>
-        <location filename="../application/logauththread.cpp" line="73"/>
-        <location filename="../application/logauththread.cpp" line="91"/>
-        <location filename="../application/logexportthread.cpp" line="3421"/>
+        <location filename="../application/displaycontent.cpp" line="180"/>
+        <location filename="../application/displaycontent.cpp" line="193"/>
+        <location filename="../application/displaycontent.cpp" line="199"/>
+        <location filename="../application/journalappwork.cpp" line="301"/>
+        <location filename="../application/journalbootwork.cpp" line="380"/>
+        <location filename="../application/journalwork.cpp" line="342"/>
+        <location filename="../application/logauththread.cpp" line="76"/>
+        <location filename="../application/logauththread.cpp" line="77"/>
+        <location filename="../application/logauththread.cpp" line="78"/>
+        <location filename="../application/logauththread.cpp" line="96"/>
+        <location filename="../application/logexportthread.cpp" line="3427"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="851"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="862"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="2980"/>
@@ -369,14 +379,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="163"/>
-        <location filename="../application/displaycontent.cpp" line="174"/>
-        <location filename="../application/displaycontent.cpp" line="182"/>
-        <location filename="../application/journalbootwork.cpp" line="420"/>
-        <location filename="../application/journalwork.cpp" line="370"/>
-        <location filename="../application/logauththread.cpp" line="74"/>
-        <location filename="../application/logauththread.cpp" line="90"/>
-        <location filename="../application/logexportthread.cpp" line="3420"/>
+        <location filename="../application/displaycontent.cpp" line="181"/>
+        <location filename="../application/displaycontent.cpp" line="192"/>
+        <location filename="../application/displaycontent.cpp" line="200"/>
+        <location filename="../application/journalappwork.cpp" line="300"/>
+        <location filename="../application/journalbootwork.cpp" line="379"/>
+        <location filename="../application/journalwork.cpp" line="341"/>
+        <location filename="../application/logauththread.cpp" line="79"/>
+        <location filename="../application/logauththread.cpp" line="95"/>
+        <location filename="../application/logexportthread.cpp" line="3426"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="852"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="861"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="2980"/>
@@ -388,14 +399,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="164"/>
-        <location filename="../application/displaycontent.cpp" line="171"/>
-        <location filename="../application/displaycontent.cpp" line="184"/>
-        <location filename="../application/journalbootwork.cpp" line="417"/>
-        <location filename="../application/journalwork.cpp" line="367"/>
-        <location filename="../application/logauththread.cpp" line="76"/>
-        <location filename="../application/logauththread.cpp" line="87"/>
-        <location filename="../application/logexportthread.cpp" line="3417"/>
+        <location filename="../application/displaycontent.cpp" line="182"/>
+        <location filename="../application/displaycontent.cpp" line="189"/>
+        <location filename="../application/displaycontent.cpp" line="202"/>
+        <location filename="../application/journalappwork.cpp" line="297"/>
+        <location filename="../application/journalbootwork.cpp" line="376"/>
+        <location filename="../application/journalwork.cpp" line="338"/>
+        <location filename="../application/logauththread.cpp" line="81"/>
+        <location filename="../application/logauththread.cpp" line="92"/>
+        <location filename="../application/logexportthread.cpp" line="3423"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="853"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="858"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="2980"/>
@@ -407,11 +419,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="168"/>
-        <location filename="../application/journalbootwork.cpp" line="414"/>
-        <location filename="../application/journalwork.cpp" line="364"/>
-        <location filename="../application/logauththread.cpp" line="84"/>
-        <location filename="../application/logexportthread.cpp" line="3414"/>
+        <location filename="../application/displaycontent.cpp" line="186"/>
+        <location filename="../application/journalappwork.cpp" line="294"/>
+        <location filename="../application/journalbootwork.cpp" line="373"/>
+        <location filename="../application/journalwork.cpp" line="335"/>
+        <location filename="../application/logauththread.cpp" line="89"/>
+        <location filename="../application/logexportthread.cpp" line="3420"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="855"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="2980"/>
         <location filename="../tests/src/ut_journalbootwork.cpp" line="132"/>
@@ -422,11 +435,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="169"/>
-        <location filename="../application/journalbootwork.cpp" line="415"/>
-        <location filename="../application/journalwork.cpp" line="365"/>
-        <location filename="../application/logauththread.cpp" line="85"/>
-        <location filename="../application/logexportthread.cpp" line="3415"/>
+        <location filename="../application/displaycontent.cpp" line="187"/>
+        <location filename="../application/journalappwork.cpp" line="295"/>
+        <location filename="../application/journalbootwork.cpp" line="374"/>
+        <location filename="../application/journalwork.cpp" line="336"/>
+        <location filename="../application/logauththread.cpp" line="90"/>
+        <location filename="../application/logexportthread.cpp" line="3421"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="856"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="2980"/>
         <location filename="../tests/src/ut_journalbootwork.cpp" line="133"/>
@@ -437,13 +451,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="170"/>
-        <location filename="../application/displaycontent.cpp" line="185"/>
-        <location filename="../application/journalbootwork.cpp" line="416"/>
-        <location filename="../application/journalwork.cpp" line="366"/>
-        <location filename="../application/logauththread.cpp" line="77"/>
-        <location filename="../application/logauththread.cpp" line="86"/>
-        <location filename="../application/logexportthread.cpp" line="3416"/>
+        <location filename="../application/displaycontent.cpp" line="188"/>
+        <location filename="../application/displaycontent.cpp" line="203"/>
+        <location filename="../application/journalappwork.cpp" line="296"/>
+        <location filename="../application/journalbootwork.cpp" line="375"/>
+        <location filename="../application/journalwork.cpp" line="337"/>
+        <location filename="../application/logauththread.cpp" line="82"/>
+        <location filename="../application/logauththread.cpp" line="91"/>
+        <location filename="../application/logexportthread.cpp" line="3422"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="857"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="2980"/>
         <location filename="../tests/src/ut_journalbootwork.cpp" line="134"/>
@@ -454,11 +469,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="173"/>
-        <location filename="../application/journalbootwork.cpp" line="419"/>
-        <location filename="../application/journalwork.cpp" line="369"/>
-        <location filename="../application/logauththread.cpp" line="89"/>
-        <location filename="../application/logexportthread.cpp" line="3419"/>
+        <location filename="../application/displaycontent.cpp" line="191"/>
+        <location filename="../application/journalappwork.cpp" line="299"/>
+        <location filename="../application/journalbootwork.cpp" line="378"/>
+        <location filename="../application/journalwork.cpp" line="340"/>
+        <location filename="../application/logauththread.cpp" line="94"/>
+        <location filename="../application/logexportthread.cpp" line="3425"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="860"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="2980"/>
         <location filename="../tests/src/ut_journalbootwork.cpp" line="137"/>
@@ -469,14 +485,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="180"/>
-        <location filename="../application/logauththread.cpp" line="70"/>
+        <location filename="../application/displaycontent.cpp" line="198"/>
+        <location filename="../application/logauththread.cpp" line="75"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="186"/>
-        <location filename="../application/logauththread.cpp" line="78"/>
+        <location filename="../application/displaycontent.cpp" line="204"/>
+        <location filename="../application/logauththread.cpp" line="83"/>
         <source>Super critical</source>
         <translation type="unfinished"></translation>
     </message>
@@ -484,7 +500,7 @@
 <context>
     <name>LogAuthThread</name>
     <message>
-        <location filename="../application/logauththread.cpp" line="499"/>
+        <location filename="../application/logauththread.cpp" line="512"/>
         <source>Log file is empty</source>
         <translation type="unfinished"></translation>
     </message>
@@ -492,13 +508,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../application/main.cpp" line="111"/>
-        <location filename="../application/main.cpp" line="112"/>
+        <location filename="../application/main.cpp" line="310"/>
+        <location filename="../application/main.cpp" line="311"/>
         <source>Log Viewer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/main.cpp" line="114"/>
+        <location filename="../application/main.cpp" line="313"/>
         <source>Log Viewer is a useful tool for viewing system logs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -506,12 +522,12 @@
 <context>
     <name>SearchBar</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="97"/>
+        <location filename="../application/displaycontent.cpp" line="104"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logcollectormain.cpp" line="90"/>
+        <location filename="../application/logcollectormain.cpp" line="92"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -519,12 +535,17 @@
 <context>
     <name>Table</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="399"/>
-        <location filename="../application/displaycontent.cpp" line="797"/>
-        <location filename="../application/displaycontent.cpp" line="1229"/>
-        <location filename="../application/displaycontent.cpp" line="1401"/>
-        <location filename="../application/displaycontent.cpp" line="1413"/>
-        <location filename="../application/logexportthread.cpp" line="2157"/>
+        <location filename="../application/displaycontent.cpp" line="418"/>
+        <location filename="../application/displaycontent.cpp" line="816"/>
+        <location filename="../application/displaycontent.cpp" line="1237"/>
+        <location filename="../application/displaycontent.cpp" line="1409"/>
+        <location filename="../application/displaycontent.cpp" line="1421"/>
+        <location filename="../application/logbackend.cpp" line="1329"/>
+        <location filename="../application/logbackend.cpp" line="1343"/>
+        <location filename="../application/logbackend.cpp" line="1366"/>
+        <location filename="../application/logbackend.cpp" line="1401"/>
+        <location filename="../application/logbackend.cpp" line="1433"/>
+        <location filename="../application/logexportthread.cpp" line="2164"/>
         <location filename="../liblogviewerplugin/src/plugins/logviewerplugin.cpp" line="279"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="955"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1198"/>
@@ -533,11 +554,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="400"/>
-        <location filename="../application/displaycontent.cpp" line="594"/>
-        <location filename="../application/displaycontent.cpp" line="1230"/>
-        <location filename="../application/displaycontent.cpp" line="3813"/>
-        <location filename="../application/logexportthread.cpp" line="2158"/>
+        <location filename="../application/displaycontent.cpp" line="419"/>
+        <location filename="../application/displaycontent.cpp" line="613"/>
+        <location filename="../application/displaycontent.cpp" line="1238"/>
+        <location filename="../application/displaycontent.cpp" line="3838"/>
+        <location filename="../application/logbackend.cpp" line="1330"/>
+        <location filename="../application/logbackend.cpp" line="1356"/>
+        <location filename="../application/logbackend.cpp" line="1367"/>
+        <location filename="../application/logbackend.cpp" line="1472"/>
+        <location filename="../application/logexportthread.cpp" line="2165"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="956"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1068"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1520"/>
@@ -545,16 +570,25 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="401"/>
-        <location filename="../application/displaycontent.cpp" line="507"/>
-        <location filename="../application/displaycontent.cpp" line="592"/>
-        <location filename="../application/displaycontent.cpp" line="798"/>
-        <location filename="../application/displaycontent.cpp" line="1231"/>
-        <location filename="../application/displaycontent.cpp" line="1402"/>
-        <location filename="../application/displaycontent.cpp" line="1414"/>
-        <location filename="../application/displaycontent.cpp" line="3812"/>
-        <location filename="../application/displaycontent.cpp" line="3923"/>
-        <location filename="../application/logexportthread.cpp" line="2160"/>
+        <location filename="../application/displaycontent.cpp" line="420"/>
+        <location filename="../application/displaycontent.cpp" line="526"/>
+        <location filename="../application/displaycontent.cpp" line="611"/>
+        <location filename="../application/displaycontent.cpp" line="817"/>
+        <location filename="../application/displaycontent.cpp" line="1239"/>
+        <location filename="../application/displaycontent.cpp" line="1410"/>
+        <location filename="../application/displaycontent.cpp" line="1422"/>
+        <location filename="../application/displaycontent.cpp" line="3837"/>
+        <location filename="../application/displaycontent.cpp" line="3948"/>
+        <location filename="../application/logbackend.cpp" line="1331"/>
+        <location filename="../application/logbackend.cpp" line="1344"/>
+        <location filename="../application/logbackend.cpp" line="1354"/>
+        <location filename="../application/logbackend.cpp" line="1368"/>
+        <location filename="../application/logbackend.cpp" line="1390"/>
+        <location filename="../application/logbackend.cpp" line="1402"/>
+        <location filename="../application/logbackend.cpp" line="1434"/>
+        <location filename="../application/logbackend.cpp" line="1446"/>
+        <location filename="../application/logbackend.cpp" line="1471"/>
+        <location filename="../application/logexportthread.cpp" line="2167"/>
         <location filename="../liblogviewerplugin/src/plugins/logviewerplugin.cpp" line="280"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="957"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1066"/>
@@ -564,19 +598,31 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="402"/>
-        <location filename="../application/displaycontent.cpp" line="508"/>
-        <location filename="../application/displaycontent.cpp" line="595"/>
-        <location filename="../application/displaycontent.cpp" line="800"/>
-        <location filename="../application/displaycontent.cpp" line="858"/>
-        <location filename="../application/displaycontent.cpp" line="954"/>
-        <location filename="../application/displaycontent.cpp" line="998"/>
-        <location filename="../application/displaycontent.cpp" line="1232"/>
-        <location filename="../application/displaycontent.cpp" line="1403"/>
-        <location filename="../application/displaycontent.cpp" line="1415"/>
-        <location filename="../application/displaycontent.cpp" line="3572"/>
-        <location filename="../application/displaycontent.cpp" line="3815"/>
-        <location filename="../application/logexportthread.cpp" line="2161"/>
+        <location filename="../application/displaycontent.cpp" line="421"/>
+        <location filename="../application/displaycontent.cpp" line="527"/>
+        <location filename="../application/displaycontent.cpp" line="614"/>
+        <location filename="../application/displaycontent.cpp" line="819"/>
+        <location filename="../application/displaycontent.cpp" line="877"/>
+        <location filename="../application/displaycontent.cpp" line="973"/>
+        <location filename="../application/displaycontent.cpp" line="1017"/>
+        <location filename="../application/displaycontent.cpp" line="1240"/>
+        <location filename="../application/displaycontent.cpp" line="1411"/>
+        <location filename="../application/displaycontent.cpp" line="1423"/>
+        <location filename="../application/displaycontent.cpp" line="3597"/>
+        <location filename="../application/displaycontent.cpp" line="3840"/>
+        <location filename="../application/logbackend.cpp" line="1332"/>
+        <location filename="../application/logbackend.cpp" line="1345"/>
+        <location filename="../application/logbackend.cpp" line="1357"/>
+        <location filename="../application/logbackend.cpp" line="1369"/>
+        <location filename="../application/logbackend.cpp" line="1381"/>
+        <location filename="../application/logbackend.cpp" line="1391"/>
+        <location filename="../application/logbackend.cpp" line="1403"/>
+        <location filename="../application/logbackend.cpp" line="1412"/>
+        <location filename="../application/logbackend.cpp" line="1422"/>
+        <location filename="../application/logbackend.cpp" line="1436"/>
+        <location filename="../application/logbackend.cpp" line="1461"/>
+        <location filename="../application/logbackend.cpp" line="1474"/>
+        <location filename="../application/logexportthread.cpp" line="2168"/>
         <location filename="../liblogviewerplugin/src/plugins/logviewerplugin.cpp" line="282"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="958"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1069"/>
@@ -586,10 +632,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="403"/>
-        <location filename="../application/displaycontent.cpp" line="593"/>
-        <location filename="../application/displaycontent.cpp" line="1233"/>
-        <location filename="../application/logexportthread.cpp" line="2162"/>
+        <location filename="../application/displaycontent.cpp" line="422"/>
+        <location filename="../application/displaycontent.cpp" line="612"/>
+        <location filename="../application/displaycontent.cpp" line="1241"/>
+        <location filename="../application/logbackend.cpp" line="1333"/>
+        <location filename="../application/logbackend.cpp" line="1355"/>
+        <location filename="../application/logbackend.cpp" line="1370"/>
+        <location filename="../application/logexportthread.cpp" line="2169"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="959"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1067"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1523"/>
@@ -597,113 +646,127 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="404"/>
-        <location filename="../application/displaycontent.cpp" line="1234"/>
-        <location filename="../application/logexportthread.cpp" line="2163"/>
+        <location filename="../application/displaycontent.cpp" line="423"/>
+        <location filename="../application/displaycontent.cpp" line="1242"/>
+        <location filename="../application/logbackend.cpp" line="1334"/>
+        <location filename="../application/logbackend.cpp" line="1371"/>
+        <location filename="../application/logexportthread.cpp" line="2170"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="960"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1524"/>
         <source>PID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="509"/>
+        <location filename="../application/displaycontent.cpp" line="528"/>
+        <location filename="../application/logbackend.cpp" line="1392"/>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="857"/>
+        <location filename="../application/displaycontent.cpp" line="876"/>
+        <location filename="../application/logbackend.cpp" line="1421"/>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3571"/>
-        <location filename="../application/displaycontent.cpp" line="3814"/>
+        <location filename="../application/displaycontent.cpp" line="3596"/>
+        <location filename="../application/displaycontent.cpp" line="3839"/>
+        <location filename="../application/logbackend.cpp" line="1380"/>
+        <location filename="../application/logbackend.cpp" line="1473"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3717"/>
+        <location filename="../application/displaycontent.cpp" line="3742"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1087"/>
         <source>File Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3718"/>
+        <location filename="../application/displaycontent.cpp" line="3743"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1088"/>
         <source>Time Modified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3922"/>
+        <location filename="../application/displaycontent.cpp" line="3947"/>
+        <location filename="../application/logbackend.cpp" line="1445"/>
         <source>SIG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3924"/>
+        <location filename="../application/displaycontent.cpp" line="3949"/>
+        <location filename="../application/logbackend.cpp" line="1447"/>
         <source>Core File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3925"/>
+        <location filename="../application/displaycontent.cpp" line="3950"/>
+        <location filename="../application/logbackend.cpp" line="1448"/>
         <source>User Name </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3926"/>
+        <location filename="../application/displaycontent.cpp" line="3951"/>
+        <location filename="../application/logbackend.cpp" line="1449"/>
         <source>EXE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="799"/>
+        <location filename="../application/displaycontent.cpp" line="818"/>
+        <location filename="../application/logbackend.cpp" line="1435"/>
         <location filename="../liblogviewerplugin/src/plugins/logviewerplugin.cpp" line="281"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1200"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="995"/>
-        <location filename="../application/displaycontent.cpp" line="3811"/>
+        <location filename="../application/displaycontent.cpp" line="1014"/>
+        <location filename="../application/displaycontent.cpp" line="3836"/>
+        <location filename="../application/logbackend.cpp" line="1458"/>
+        <location filename="../application/logbackend.cpp" line="1470"/>
         <source>Event Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="996"/>
+        <location filename="../application/displaycontent.cpp" line="1015"/>
+        <location filename="../application/logbackend.cpp" line="1459"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logexportthread.cpp" line="789"/>
+        <location filename="../application/logexportthread.cpp" line="796"/>
         <source>Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logexportthread.cpp" line="790"/>
+        <location filename="../application/logexportthread.cpp" line="797"/>
         <source>Process:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logexportthread.cpp" line="791"/>
+        <location filename="../application/logexportthread.cpp" line="798"/>
         <source>Date and Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logexportthread.cpp" line="793"/>
-        <location filename="../application/logexportthread.cpp" line="796"/>
+        <location filename="../application/logexportthread.cpp" line="800"/>
+        <location filename="../application/logexportthread.cpp" line="803"/>
         <source>Info:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logexportthread.cpp" line="794"/>
+        <location filename="../application/logexportthread.cpp" line="801"/>
         <source>Null</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logexportthread.cpp" line="798"/>
+        <location filename="../application/logexportthread.cpp" line="805"/>
         <source>User:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logexportthread.cpp" line="799"/>
+        <location filename="../application/logexportthread.cpp" line="806"/>
         <source>PID:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -711,7 +774,8 @@
 <context>
     <name>Tbble</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="997"/>
+        <location filename="../application/displaycontent.cpp" line="1016"/>
+        <location filename="../application/logbackend.cpp" line="1460"/>
         <source>Date and Time</source>
         <translation type="unfinished"></translation>
     </message>
@@ -719,84 +783,84 @@
 <context>
     <name>Tree</name>
     <message>
-        <location filename="../application/loglistview.cpp" line="156"/>
-        <location filename="../application/loglistview.cpp" line="158"/>
+        <location filename="../application/loglistview.cpp" line="157"/>
+        <location filename="../application/loglistview.cpp" line="159"/>
         <source>System Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../application/loglistview.cpp" line="168"/>
         <location filename="../application/loglistview.cpp" line="170"/>
-        <location filename="../application/loglistview.cpp" line="179"/>
-        <location filename="../application/loglistview.cpp" line="181"/>
+        <location filename="../application/loglistview.cpp" line="178"/>
+        <location filename="../application/loglistview.cpp" line="180"/>
         <source>Kernel Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../application/loglistview.cpp" line="189"/>
         <location filename="../application/loglistview.cpp" line="191"/>
-        <location filename="../application/loglistview.cpp" line="193"/>
-        <location filename="../application/loglistview.cpp" line="201"/>
-        <location filename="../application/loglistview.cpp" line="203"/>
+        <location filename="../application/loglistview.cpp" line="198"/>
+        <location filename="../application/loglistview.cpp" line="200"/>
         <source>Boot Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="212"/>
-        <location filename="../application/loglistview.cpp" line="214"/>
+        <location filename="../application/loglistview.cpp" line="208"/>
+        <location filename="../application/loglistview.cpp" line="210"/>
         <source>dnf Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="223"/>
-        <location filename="../application/loglistview.cpp" line="225"/>
+        <location filename="../application/loglistview.cpp" line="218"/>
+        <location filename="../application/loglistview.cpp" line="220"/>
         <source>dpkg Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="246"/>
-        <location filename="../application/loglistview.cpp" line="248"/>
+        <location filename="../application/loglistview.cpp" line="239"/>
+        <location filename="../application/loglistview.cpp" line="241"/>
         <source>Xorg Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="273"/>
-        <location filename="../application/loglistview.cpp" line="275"/>
+        <location filename="../application/loglistview.cpp" line="264"/>
+        <location filename="../application/loglistview.cpp" line="266"/>
         <source>Coredump Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="300"/>
-        <location filename="../application/loglistview.cpp" line="302"/>
+        <location filename="../application/loglistview.cpp" line="289"/>
+        <location filename="../application/loglistview.cpp" line="291"/>
         <source>Other Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="318"/>
-        <location filename="../application/loglistview.cpp" line="320"/>
+        <location filename="../application/loglistview.cpp" line="306"/>
+        <location filename="../application/loglistview.cpp" line="308"/>
         <source>Audit Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="338"/>
-        <location filename="../application/loglistview.cpp" line="342"/>
+        <location filename="../application/loglistview.cpp" line="325"/>
+        <location filename="../application/loglistview.cpp" line="329"/>
         <source>Custom Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="236"/>
-        <location filename="../application/loglistview.cpp" line="238"/>
+        <location filename="../application/loglistview.cpp" line="230"/>
+        <location filename="../application/loglistview.cpp" line="232"/>
         <source>Kwin Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="259"/>
-        <location filename="../application/loglistview.cpp" line="262"/>
+        <location filename="../application/loglistview.cpp" line="251"/>
+        <location filename="../application/loglistview.cpp" line="254"/>
         <source>Application Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="286"/>
-        <location filename="../application/loglistview.cpp" line="290"/>
+        <location filename="../application/loglistview.cpp" line="276"/>
+        <location filename="../application/loglistview.cpp" line="280"/>
         <source>Boot-Shutdown Event</source>
         <translation type="unfinished"></translation>
     </message>
@@ -804,7 +868,7 @@
 <context>
     <name>Waring</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="110"/>
+        <location filename="../application/displaycontent.cpp" line="117"/>
         <source>Unable to obtain crash information, please install systemd-coredump.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -812,13 +876,13 @@
 <context>
     <name>Warning</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="104"/>
+        <location filename="../application/displaycontent.cpp" line="111"/>
         <source>Security level for the current system: high
  audit only administrators can view the audit log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="2276"/>
+        <location filename="../application/displaycontent.cpp" line="2307"/>
         <source>You do not have permission to view it</source>
         <translation type="unfinished"></translation>
     </message>
@@ -826,51 +890,128 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../application/main.cpp" line="39"/>
-        <source>export logs</source>
+        <location filename="../application/main.cpp" line="58"/>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/main.cpp" line="42"/>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <location filename="../application/main.cpp" line="58"/>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="59"/>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="59"/>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="60"/>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="60"/>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="61"/>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="61"/>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="62"/>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="62"/>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="63"/>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="63"/>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="64"/>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="64"/>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="65"/>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="65"/>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="66"/>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>titlebar</name>
     <message>
-        <location filename="../application/logcollectormain.cpp" line="179"/>
+        <location filename="../application/logcollectormain.cpp" line="184"/>
         <source>Refresh interval</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logcollectormain.cpp" line="180"/>
+        <location filename="../application/logcollectormain.cpp" line="186"/>
         <source>10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logcollectormain.cpp" line="181"/>
+        <location filename="../application/logcollectormain.cpp" line="187"/>
         <source>1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logcollectormain.cpp" line="182"/>
+        <location filename="../application/logcollectormain.cpp" line="188"/>
         <location filename="../tests/src/ut_logcollectormain.cpp" line="322"/>
         <source>5 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logcollectormain.cpp" line="183"/>
+        <location filename="../application/logcollectormain.cpp" line="189"/>
         <source>No refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logcollectormain.cpp" line="210"/>
+        <location filename="../application/logcollectormain.cpp" line="216"/>
+        <location filename="../application/logcollectormain.cpp" line="217"/>
         <source>Export All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logcollectormain.cpp" line="215"/>
+        <location filename="../application/logcollectormain.cpp" line="222"/>
+        <location filename="../application/logcollectormain.cpp" line="223"/>
         <source>Refresh Now</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin_log_viewer_en_US.ts
+++ b/translations/deepin_log_viewer_en_US.ts
@@ -4,34 +4,34 @@
 <context>
     <name>Action</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3956"/>
-        <location filename="../application/loglistview.cpp" line="448"/>
+        <location filename="../application/displaycontent.cpp" line="166"/>
+        <location filename="../application/loglistview.cpp" line="433"/>
         <source>Display in file manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="449"/>
+        <location filename="../application/loglistview.cpp" line="434"/>
         <source>Clear log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3957"/>
-        <location filename="../application/loglistview.cpp" line="450"/>
+        <location filename="../application/displaycontent.cpp" line="167"/>
+        <location filename="../application/loglistview.cpp" line="435"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="497"/>
+        <location filename="../application/loglistview.cpp" line="482"/>
         <source>Are you sure you want to clear the log?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="498"/>
+        <location filename="../application/loglistview.cpp" line="483"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="499"/>
+        <location filename="../application/loglistview.cpp" line="484"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -41,52 +41,52 @@
     <message>
         <location filename="../application/filtercontent.cpp" line="67"/>
         <location filename="../application/filtercontent.cpp" line="68"/>
-        <location filename="../application/filtercontent.cpp" line="575"/>
+        <location filename="../application/filtercontent.cpp" line="576"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../application/filtercontent.cpp" line="70"/>
         <location filename="../application/filtercontent.cpp" line="71"/>
-        <location filename="../application/filtercontent.cpp" line="568"/>
-        <location filename="../application/filtercontent.cpp" line="576"/>
+        <location filename="../application/filtercontent.cpp" line="569"/>
+        <location filename="../application/filtercontent.cpp" line="577"/>
         <source>Today</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../application/filtercontent.cpp" line="73"/>
         <location filename="../application/filtercontent.cpp" line="74"/>
-        <location filename="../application/filtercontent.cpp" line="569"/>
-        <location filename="../application/filtercontent.cpp" line="577"/>
+        <location filename="../application/filtercontent.cpp" line="570"/>
+        <location filename="../application/filtercontent.cpp" line="578"/>
         <source>3 days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../application/filtercontent.cpp" line="76"/>
         <location filename="../application/filtercontent.cpp" line="77"/>
-        <location filename="../application/filtercontent.cpp" line="570"/>
-        <location filename="../application/filtercontent.cpp" line="578"/>
+        <location filename="../application/filtercontent.cpp" line="571"/>
+        <location filename="../application/filtercontent.cpp" line="579"/>
         <source>1 week</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../application/filtercontent.cpp" line="79"/>
         <location filename="../application/filtercontent.cpp" line="80"/>
-        <location filename="../application/filtercontent.cpp" line="571"/>
-        <location filename="../application/filtercontent.cpp" line="579"/>
+        <location filename="../application/filtercontent.cpp" line="572"/>
+        <location filename="../application/filtercontent.cpp" line="580"/>
         <source>1 month</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../application/filtercontent.cpp" line="82"/>
         <location filename="../application/filtercontent.cpp" line="83"/>
-        <location filename="../application/filtercontent.cpp" line="572"/>
-        <location filename="../application/filtercontent.cpp" line="580"/>
+        <location filename="../application/filtercontent.cpp" line="573"/>
+        <location filename="../application/filtercontent.cpp" line="581"/>
         <source>3 months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="200"/>
+        <location filename="../application/filtercontent.cpp" line="201"/>
         <source>Export</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -95,112 +95,112 @@
 <context>
     <name>ComboBox</name>
     <message>
-        <location filename="../application/filtercontent.cpp" line="111"/>
-        <location filename="../application/filtercontent.cpp" line="130"/>
+        <location filename="../application/filtercontent.cpp" line="107"/>
+        <location filename="../application/filtercontent.cpp" line="128"/>
         <location filename="../application/filtercontent.cpp" line="159"/>
-        <location filename="../application/filtercontent.cpp" line="172"/>
-        <location filename="../application/filtercontent.cpp" line="187"/>
+        <location filename="../application/filtercontent.cpp" line="173"/>
+        <location filename="../application/filtercontent.cpp" line="188"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="112"/>
+        <location filename="../application/filtercontent.cpp" line="108"/>
         <source>Emergency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="113"/>
+        <location filename="../application/filtercontent.cpp" line="109"/>
         <source>Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="114"/>
-        <location filename="../application/filtercontent.cpp" line="132"/>
+        <location filename="../application/filtercontent.cpp" line="110"/>
+        <location filename="../application/filtercontent.cpp" line="130"/>
         <source>Critical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="115"/>
-        <location filename="../application/filtercontent.cpp" line="133"/>
+        <location filename="../application/filtercontent.cpp" line="111"/>
+        <location filename="../application/filtercontent.cpp" line="131"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="116"/>
-        <location filename="../application/filtercontent.cpp" line="134"/>
+        <location filename="../application/filtercontent.cpp" line="112"/>
+        <location filename="../application/filtercontent.cpp" line="132"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="117"/>
+        <location filename="../application/filtercontent.cpp" line="113"/>
         <source>Notice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="118"/>
-        <location filename="../application/filtercontent.cpp" line="120"/>
-        <location filename="../application/filtercontent.cpp" line="135"/>
+        <location filename="../application/filtercontent.cpp" line="114"/>
+        <location filename="../application/filtercontent.cpp" line="116"/>
+        <location filename="../application/filtercontent.cpp" line="133"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="119"/>
-        <location filename="../application/filtercontent.cpp" line="136"/>
+        <location filename="../application/filtercontent.cpp" line="115"/>
+        <location filename="../application/filtercontent.cpp" line="134"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="131"/>
+        <location filename="../application/filtercontent.cpp" line="129"/>
         <source>Super critical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="137"/>
+        <location filename="../application/filtercontent.cpp" line="135"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="173"/>
+        <location filename="../application/filtercontent.cpp" line="174"/>
         <source>Login</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="174"/>
+        <location filename="../application/filtercontent.cpp" line="175"/>
         <source>Boot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="175"/>
+        <location filename="../application/filtercontent.cpp" line="176"/>
         <source>Shutdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="188"/>
+        <location filename="../application/filtercontent.cpp" line="189"/>
         <source>Identity authentication</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="189"/>
+        <location filename="../application/filtercontent.cpp" line="190"/>
         <source>Discretionary Access Control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="190"/>
+        <location filename="../application/filtercontent.cpp" line="191"/>
         <source>Mandatory access control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="191"/>
+        <location filename="../application/filtercontent.cpp" line="192"/>
         <source>Remote</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="192"/>
+        <location filename="../application/filtercontent.cpp" line="193"/>
         <source>Document audit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="193"/>
+        <location filename="../application/filtercontent.cpp" line="194"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -208,12 +208,12 @@
 <context>
     <name>DisplayContent</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="1643"/>
+        <location filename="../application/displaycontent.cpp" line="1647"/>
         <source>TEXT (*.txt);; Doc (*.doc);; Xls (*.xls);; Html (*.html))</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="1649"/>
+        <location filename="../application/displaycontent.cpp" line="1653"/>
         <source>zip(*.zip)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -234,21 +234,27 @@
 <context>
     <name>ExportMessage</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3203"/>
+        <location filename="../application/displaycontent.cpp" line="3229"/>
         <source>Export successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3206"/>
+        <location filename="../application/displaycontent.cpp" line="3232"/>
         <source>Export failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/logcollectormain.cpp" line="328"/>
+        <location filename="../application/main.cpp" line="171"/>
+        <source>The export directory is not available. Please choose another directory for the export operation.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>File</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="1641"/>
-        <location filename="../application/displaycontent.cpp" line="1647"/>
+        <location filename="../application/displaycontent.cpp" line="1645"/>
+        <location filename="../application/displaycontent.cpp" line="1651"/>
         <source>Export File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -257,24 +263,26 @@
     <name>Label</name>
     <message>
         <location filename="../application/filtercontent.cpp" line="63"/>
-        <location filename="../application/filtercontent.cpp" line="567"/>
-        <location filename="../application/filtercontent.cpp" line="574"/>
+        <location filename="../application/filtercontent.cpp" line="568"/>
+        <location filename="../application/filtercontent.cpp" line="575"/>
         <source>Period:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="107"/>
-        <location filename="../application/filtercontent.cpp" line="126"/>
+        <location filename="../application/filtercontent.cpp" line="101"/>
+        <location filename="../application/filtercontent.cpp" line="102"/>
+        <location filename="../application/filtercontent.cpp" line="122"/>
+        <location filename="../application/filtercontent.cpp" line="123"/>
         <source>Level:  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="144"/>
+        <location filename="../application/filtercontent.cpp" line="142"/>
         <source>Application list:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="155"/>
+        <location filename="../application/filtercontent.cpp" line="154"/>
         <location filename="../application/logdetailinfowidget.cpp" line="156"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
@@ -286,7 +294,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/filtercontent.cpp" line="183"/>
+        <location filename="../application/filtercontent.cpp" line="184"/>
         <source>Audit Type:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,14 +337,15 @@
 <context>
     <name>Level</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="161"/>
-        <location filename="../application/displaycontent.cpp" line="172"/>
-        <location filename="../application/displaycontent.cpp" line="183"/>
-        <location filename="../application/journalbootwork.cpp" line="418"/>
-        <location filename="../application/journalwork.cpp" line="368"/>
-        <location filename="../application/logauththread.cpp" line="75"/>
-        <location filename="../application/logauththread.cpp" line="88"/>
-        <location filename="../application/logexportthread.cpp" line="3418"/>
+        <location filename="../application/displaycontent.cpp" line="179"/>
+        <location filename="../application/displaycontent.cpp" line="190"/>
+        <location filename="../application/displaycontent.cpp" line="201"/>
+        <location filename="../application/journalappwork.cpp" line="298"/>
+        <location filename="../application/journalbootwork.cpp" line="377"/>
+        <location filename="../application/journalwork.cpp" line="339"/>
+        <location filename="../application/logauththread.cpp" line="80"/>
+        <location filename="../application/logauththread.cpp" line="93"/>
+        <location filename="../application/logexportthread.cpp" line="3424"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="850"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="859"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="2980"/>
@@ -348,16 +357,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="162"/>
-        <location filename="../application/displaycontent.cpp" line="175"/>
-        <location filename="../application/displaycontent.cpp" line="181"/>
-        <location filename="../application/journalbootwork.cpp" line="421"/>
-        <location filename="../application/journalwork.cpp" line="371"/>
-        <location filename="../application/logauththread.cpp" line="71"/>
-        <location filename="../application/logauththread.cpp" line="72"/>
-        <location filename="../application/logauththread.cpp" line="73"/>
-        <location filename="../application/logauththread.cpp" line="91"/>
-        <location filename="../application/logexportthread.cpp" line="3421"/>
+        <location filename="../application/displaycontent.cpp" line="180"/>
+        <location filename="../application/displaycontent.cpp" line="193"/>
+        <location filename="../application/displaycontent.cpp" line="199"/>
+        <location filename="../application/journalappwork.cpp" line="301"/>
+        <location filename="../application/journalbootwork.cpp" line="380"/>
+        <location filename="../application/journalwork.cpp" line="342"/>
+        <location filename="../application/logauththread.cpp" line="76"/>
+        <location filename="../application/logauththread.cpp" line="77"/>
+        <location filename="../application/logauththread.cpp" line="78"/>
+        <location filename="../application/logauththread.cpp" line="96"/>
+        <location filename="../application/logexportthread.cpp" line="3427"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="851"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="862"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="2980"/>
@@ -369,14 +379,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="163"/>
-        <location filename="../application/displaycontent.cpp" line="174"/>
-        <location filename="../application/displaycontent.cpp" line="182"/>
-        <location filename="../application/journalbootwork.cpp" line="420"/>
-        <location filename="../application/journalwork.cpp" line="370"/>
-        <location filename="../application/logauththread.cpp" line="74"/>
-        <location filename="../application/logauththread.cpp" line="90"/>
-        <location filename="../application/logexportthread.cpp" line="3420"/>
+        <location filename="../application/displaycontent.cpp" line="181"/>
+        <location filename="../application/displaycontent.cpp" line="192"/>
+        <location filename="../application/displaycontent.cpp" line="200"/>
+        <location filename="../application/journalappwork.cpp" line="300"/>
+        <location filename="../application/journalbootwork.cpp" line="379"/>
+        <location filename="../application/journalwork.cpp" line="341"/>
+        <location filename="../application/logauththread.cpp" line="79"/>
+        <location filename="../application/logauththread.cpp" line="95"/>
+        <location filename="../application/logexportthread.cpp" line="3426"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="852"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="861"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="2980"/>
@@ -388,14 +399,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="164"/>
-        <location filename="../application/displaycontent.cpp" line="171"/>
-        <location filename="../application/displaycontent.cpp" line="184"/>
-        <location filename="../application/journalbootwork.cpp" line="417"/>
-        <location filename="../application/journalwork.cpp" line="367"/>
-        <location filename="../application/logauththread.cpp" line="76"/>
-        <location filename="../application/logauththread.cpp" line="87"/>
-        <location filename="../application/logexportthread.cpp" line="3417"/>
+        <location filename="../application/displaycontent.cpp" line="182"/>
+        <location filename="../application/displaycontent.cpp" line="189"/>
+        <location filename="../application/displaycontent.cpp" line="202"/>
+        <location filename="../application/journalappwork.cpp" line="297"/>
+        <location filename="../application/journalbootwork.cpp" line="376"/>
+        <location filename="../application/journalwork.cpp" line="338"/>
+        <location filename="../application/logauththread.cpp" line="81"/>
+        <location filename="../application/logauththread.cpp" line="92"/>
+        <location filename="../application/logexportthread.cpp" line="3423"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="853"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="858"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="2980"/>
@@ -407,11 +419,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="168"/>
-        <location filename="../application/journalbootwork.cpp" line="414"/>
-        <location filename="../application/journalwork.cpp" line="364"/>
-        <location filename="../application/logauththread.cpp" line="84"/>
-        <location filename="../application/logexportthread.cpp" line="3414"/>
+        <location filename="../application/displaycontent.cpp" line="186"/>
+        <location filename="../application/journalappwork.cpp" line="294"/>
+        <location filename="../application/journalbootwork.cpp" line="373"/>
+        <location filename="../application/journalwork.cpp" line="335"/>
+        <location filename="../application/logauththread.cpp" line="89"/>
+        <location filename="../application/logexportthread.cpp" line="3420"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="855"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="2980"/>
         <location filename="../tests/src/ut_journalbootwork.cpp" line="132"/>
@@ -422,11 +435,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="169"/>
-        <location filename="../application/journalbootwork.cpp" line="415"/>
-        <location filename="../application/journalwork.cpp" line="365"/>
-        <location filename="../application/logauththread.cpp" line="85"/>
-        <location filename="../application/logexportthread.cpp" line="3415"/>
+        <location filename="../application/displaycontent.cpp" line="187"/>
+        <location filename="../application/journalappwork.cpp" line="295"/>
+        <location filename="../application/journalbootwork.cpp" line="374"/>
+        <location filename="../application/journalwork.cpp" line="336"/>
+        <location filename="../application/logauththread.cpp" line="90"/>
+        <location filename="../application/logexportthread.cpp" line="3421"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="856"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="2980"/>
         <location filename="../tests/src/ut_journalbootwork.cpp" line="133"/>
@@ -437,13 +451,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="170"/>
-        <location filename="../application/displaycontent.cpp" line="185"/>
-        <location filename="../application/journalbootwork.cpp" line="416"/>
-        <location filename="../application/journalwork.cpp" line="366"/>
-        <location filename="../application/logauththread.cpp" line="77"/>
-        <location filename="../application/logauththread.cpp" line="86"/>
-        <location filename="../application/logexportthread.cpp" line="3416"/>
+        <location filename="../application/displaycontent.cpp" line="188"/>
+        <location filename="../application/displaycontent.cpp" line="203"/>
+        <location filename="../application/journalappwork.cpp" line="296"/>
+        <location filename="../application/journalbootwork.cpp" line="375"/>
+        <location filename="../application/journalwork.cpp" line="337"/>
+        <location filename="../application/logauththread.cpp" line="82"/>
+        <location filename="../application/logauththread.cpp" line="91"/>
+        <location filename="../application/logexportthread.cpp" line="3422"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="857"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="2980"/>
         <location filename="../tests/src/ut_journalbootwork.cpp" line="134"/>
@@ -454,11 +469,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="173"/>
-        <location filename="../application/journalbootwork.cpp" line="419"/>
-        <location filename="../application/journalwork.cpp" line="369"/>
-        <location filename="../application/logauththread.cpp" line="89"/>
-        <location filename="../application/logexportthread.cpp" line="3419"/>
+        <location filename="../application/displaycontent.cpp" line="191"/>
+        <location filename="../application/journalappwork.cpp" line="299"/>
+        <location filename="../application/journalbootwork.cpp" line="378"/>
+        <location filename="../application/journalwork.cpp" line="340"/>
+        <location filename="../application/logauththread.cpp" line="94"/>
+        <location filename="../application/logexportthread.cpp" line="3425"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="860"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="2980"/>
         <location filename="../tests/src/ut_journalbootwork.cpp" line="137"/>
@@ -469,14 +485,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="180"/>
-        <location filename="../application/logauththread.cpp" line="70"/>
+        <location filename="../application/displaycontent.cpp" line="198"/>
+        <location filename="../application/logauththread.cpp" line="75"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="186"/>
-        <location filename="../application/logauththread.cpp" line="78"/>
+        <location filename="../application/displaycontent.cpp" line="204"/>
+        <location filename="../application/logauththread.cpp" line="83"/>
         <source>Super critical</source>
         <translation type="unfinished"></translation>
     </message>
@@ -484,7 +500,7 @@
 <context>
     <name>LogAuthThread</name>
     <message>
-        <location filename="../application/logauththread.cpp" line="499"/>
+        <location filename="../application/logauththread.cpp" line="512"/>
         <source>Log file is empty</source>
         <translation type="unfinished"></translation>
     </message>
@@ -492,13 +508,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../application/main.cpp" line="111"/>
-        <location filename="../application/main.cpp" line="112"/>
+        <location filename="../application/main.cpp" line="310"/>
+        <location filename="../application/main.cpp" line="311"/>
         <source>Log Viewer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/main.cpp" line="114"/>
+        <location filename="../application/main.cpp" line="313"/>
         <source>Log Viewer is a useful tool for viewing system logs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -506,12 +522,12 @@
 <context>
     <name>SearchBar</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="97"/>
+        <location filename="../application/displaycontent.cpp" line="104"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logcollectormain.cpp" line="90"/>
+        <location filename="../application/logcollectormain.cpp" line="92"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -519,12 +535,17 @@
 <context>
     <name>Table</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="399"/>
-        <location filename="../application/displaycontent.cpp" line="797"/>
-        <location filename="../application/displaycontent.cpp" line="1229"/>
-        <location filename="../application/displaycontent.cpp" line="1401"/>
-        <location filename="../application/displaycontent.cpp" line="1413"/>
-        <location filename="../application/logexportthread.cpp" line="2157"/>
+        <location filename="../application/displaycontent.cpp" line="418"/>
+        <location filename="../application/displaycontent.cpp" line="816"/>
+        <location filename="../application/displaycontent.cpp" line="1237"/>
+        <location filename="../application/displaycontent.cpp" line="1409"/>
+        <location filename="../application/displaycontent.cpp" line="1421"/>
+        <location filename="../application/logbackend.cpp" line="1329"/>
+        <location filename="../application/logbackend.cpp" line="1343"/>
+        <location filename="../application/logbackend.cpp" line="1366"/>
+        <location filename="../application/logbackend.cpp" line="1401"/>
+        <location filename="../application/logbackend.cpp" line="1433"/>
+        <location filename="../application/logexportthread.cpp" line="2164"/>
         <location filename="../liblogviewerplugin/src/plugins/logviewerplugin.cpp" line="279"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="955"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1198"/>
@@ -533,11 +554,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="400"/>
-        <location filename="../application/displaycontent.cpp" line="594"/>
-        <location filename="../application/displaycontent.cpp" line="1230"/>
-        <location filename="../application/displaycontent.cpp" line="3813"/>
-        <location filename="../application/logexportthread.cpp" line="2158"/>
+        <location filename="../application/displaycontent.cpp" line="419"/>
+        <location filename="../application/displaycontent.cpp" line="613"/>
+        <location filename="../application/displaycontent.cpp" line="1238"/>
+        <location filename="../application/displaycontent.cpp" line="3838"/>
+        <location filename="../application/logbackend.cpp" line="1330"/>
+        <location filename="../application/logbackend.cpp" line="1356"/>
+        <location filename="../application/logbackend.cpp" line="1367"/>
+        <location filename="../application/logbackend.cpp" line="1472"/>
+        <location filename="../application/logexportthread.cpp" line="2165"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="956"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1068"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1520"/>
@@ -545,16 +570,25 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="401"/>
-        <location filename="../application/displaycontent.cpp" line="507"/>
-        <location filename="../application/displaycontent.cpp" line="592"/>
-        <location filename="../application/displaycontent.cpp" line="798"/>
-        <location filename="../application/displaycontent.cpp" line="1231"/>
-        <location filename="../application/displaycontent.cpp" line="1402"/>
-        <location filename="../application/displaycontent.cpp" line="1414"/>
-        <location filename="../application/displaycontent.cpp" line="3812"/>
-        <location filename="../application/displaycontent.cpp" line="3923"/>
-        <location filename="../application/logexportthread.cpp" line="2160"/>
+        <location filename="../application/displaycontent.cpp" line="420"/>
+        <location filename="../application/displaycontent.cpp" line="526"/>
+        <location filename="../application/displaycontent.cpp" line="611"/>
+        <location filename="../application/displaycontent.cpp" line="817"/>
+        <location filename="../application/displaycontent.cpp" line="1239"/>
+        <location filename="../application/displaycontent.cpp" line="1410"/>
+        <location filename="../application/displaycontent.cpp" line="1422"/>
+        <location filename="../application/displaycontent.cpp" line="3837"/>
+        <location filename="../application/displaycontent.cpp" line="3948"/>
+        <location filename="../application/logbackend.cpp" line="1331"/>
+        <location filename="../application/logbackend.cpp" line="1344"/>
+        <location filename="../application/logbackend.cpp" line="1354"/>
+        <location filename="../application/logbackend.cpp" line="1368"/>
+        <location filename="../application/logbackend.cpp" line="1390"/>
+        <location filename="../application/logbackend.cpp" line="1402"/>
+        <location filename="../application/logbackend.cpp" line="1434"/>
+        <location filename="../application/logbackend.cpp" line="1446"/>
+        <location filename="../application/logbackend.cpp" line="1471"/>
+        <location filename="../application/logexportthread.cpp" line="2167"/>
         <location filename="../liblogviewerplugin/src/plugins/logviewerplugin.cpp" line="280"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="957"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1066"/>
@@ -564,19 +598,31 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="402"/>
-        <location filename="../application/displaycontent.cpp" line="508"/>
-        <location filename="../application/displaycontent.cpp" line="595"/>
-        <location filename="../application/displaycontent.cpp" line="800"/>
-        <location filename="../application/displaycontent.cpp" line="858"/>
-        <location filename="../application/displaycontent.cpp" line="954"/>
-        <location filename="../application/displaycontent.cpp" line="998"/>
-        <location filename="../application/displaycontent.cpp" line="1232"/>
-        <location filename="../application/displaycontent.cpp" line="1403"/>
-        <location filename="../application/displaycontent.cpp" line="1415"/>
-        <location filename="../application/displaycontent.cpp" line="3572"/>
-        <location filename="../application/displaycontent.cpp" line="3815"/>
-        <location filename="../application/logexportthread.cpp" line="2161"/>
+        <location filename="../application/displaycontent.cpp" line="421"/>
+        <location filename="../application/displaycontent.cpp" line="527"/>
+        <location filename="../application/displaycontent.cpp" line="614"/>
+        <location filename="../application/displaycontent.cpp" line="819"/>
+        <location filename="../application/displaycontent.cpp" line="877"/>
+        <location filename="../application/displaycontent.cpp" line="973"/>
+        <location filename="../application/displaycontent.cpp" line="1017"/>
+        <location filename="../application/displaycontent.cpp" line="1240"/>
+        <location filename="../application/displaycontent.cpp" line="1411"/>
+        <location filename="../application/displaycontent.cpp" line="1423"/>
+        <location filename="../application/displaycontent.cpp" line="3597"/>
+        <location filename="../application/displaycontent.cpp" line="3840"/>
+        <location filename="../application/logbackend.cpp" line="1332"/>
+        <location filename="../application/logbackend.cpp" line="1345"/>
+        <location filename="../application/logbackend.cpp" line="1357"/>
+        <location filename="../application/logbackend.cpp" line="1369"/>
+        <location filename="../application/logbackend.cpp" line="1381"/>
+        <location filename="../application/logbackend.cpp" line="1391"/>
+        <location filename="../application/logbackend.cpp" line="1403"/>
+        <location filename="../application/logbackend.cpp" line="1412"/>
+        <location filename="../application/logbackend.cpp" line="1422"/>
+        <location filename="../application/logbackend.cpp" line="1436"/>
+        <location filename="../application/logbackend.cpp" line="1461"/>
+        <location filename="../application/logbackend.cpp" line="1474"/>
+        <location filename="../application/logexportthread.cpp" line="2168"/>
         <location filename="../liblogviewerplugin/src/plugins/logviewerplugin.cpp" line="282"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="958"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1069"/>
@@ -586,10 +632,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="403"/>
-        <location filename="../application/displaycontent.cpp" line="593"/>
-        <location filename="../application/displaycontent.cpp" line="1233"/>
-        <location filename="../application/logexportthread.cpp" line="2162"/>
+        <location filename="../application/displaycontent.cpp" line="422"/>
+        <location filename="../application/displaycontent.cpp" line="612"/>
+        <location filename="../application/displaycontent.cpp" line="1241"/>
+        <location filename="../application/logbackend.cpp" line="1333"/>
+        <location filename="../application/logbackend.cpp" line="1355"/>
+        <location filename="../application/logbackend.cpp" line="1370"/>
+        <location filename="../application/logexportthread.cpp" line="2169"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="959"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1067"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1523"/>
@@ -597,113 +646,127 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="404"/>
-        <location filename="../application/displaycontent.cpp" line="1234"/>
-        <location filename="../application/logexportthread.cpp" line="2163"/>
+        <location filename="../application/displaycontent.cpp" line="423"/>
+        <location filename="../application/displaycontent.cpp" line="1242"/>
+        <location filename="../application/logbackend.cpp" line="1334"/>
+        <location filename="../application/logbackend.cpp" line="1371"/>
+        <location filename="../application/logexportthread.cpp" line="2170"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="960"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1524"/>
         <source>PID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="509"/>
+        <location filename="../application/displaycontent.cpp" line="528"/>
+        <location filename="../application/logbackend.cpp" line="1392"/>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="857"/>
+        <location filename="../application/displaycontent.cpp" line="876"/>
+        <location filename="../application/logbackend.cpp" line="1421"/>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3571"/>
-        <location filename="../application/displaycontent.cpp" line="3814"/>
+        <location filename="../application/displaycontent.cpp" line="3596"/>
+        <location filename="../application/displaycontent.cpp" line="3839"/>
+        <location filename="../application/logbackend.cpp" line="1380"/>
+        <location filename="../application/logbackend.cpp" line="1473"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3717"/>
+        <location filename="../application/displaycontent.cpp" line="3742"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1087"/>
         <source>File Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3718"/>
+        <location filename="../application/displaycontent.cpp" line="3743"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1088"/>
         <source>Time Modified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3922"/>
+        <location filename="../application/displaycontent.cpp" line="3947"/>
+        <location filename="../application/logbackend.cpp" line="1445"/>
         <source>SIG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3924"/>
+        <location filename="../application/displaycontent.cpp" line="3949"/>
+        <location filename="../application/logbackend.cpp" line="1447"/>
         <source>Core File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3925"/>
+        <location filename="../application/displaycontent.cpp" line="3950"/>
+        <location filename="../application/logbackend.cpp" line="1448"/>
         <source>User Name </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="3926"/>
+        <location filename="../application/displaycontent.cpp" line="3951"/>
+        <location filename="../application/logbackend.cpp" line="1449"/>
         <source>EXE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="799"/>
+        <location filename="../application/displaycontent.cpp" line="818"/>
+        <location filename="../application/logbackend.cpp" line="1435"/>
         <location filename="../liblogviewerplugin/src/plugins/logviewerplugin.cpp" line="281"/>
         <location filename="../tests/src/ut_displaycontent.cpp" line="1200"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="995"/>
-        <location filename="../application/displaycontent.cpp" line="3811"/>
+        <location filename="../application/displaycontent.cpp" line="1014"/>
+        <location filename="../application/displaycontent.cpp" line="3836"/>
+        <location filename="../application/logbackend.cpp" line="1458"/>
+        <location filename="../application/logbackend.cpp" line="1470"/>
         <source>Event Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="996"/>
+        <location filename="../application/displaycontent.cpp" line="1015"/>
+        <location filename="../application/logbackend.cpp" line="1459"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logexportthread.cpp" line="789"/>
+        <location filename="../application/logexportthread.cpp" line="796"/>
         <source>Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logexportthread.cpp" line="790"/>
+        <location filename="../application/logexportthread.cpp" line="797"/>
         <source>Process:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logexportthread.cpp" line="791"/>
+        <location filename="../application/logexportthread.cpp" line="798"/>
         <source>Date and Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logexportthread.cpp" line="793"/>
-        <location filename="../application/logexportthread.cpp" line="796"/>
+        <location filename="../application/logexportthread.cpp" line="800"/>
+        <location filename="../application/logexportthread.cpp" line="803"/>
         <source>Info:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logexportthread.cpp" line="794"/>
+        <location filename="../application/logexportthread.cpp" line="801"/>
         <source>Null</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logexportthread.cpp" line="798"/>
+        <location filename="../application/logexportthread.cpp" line="805"/>
         <source>User:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logexportthread.cpp" line="799"/>
+        <location filename="../application/logexportthread.cpp" line="806"/>
         <source>PID:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -711,7 +774,8 @@
 <context>
     <name>Tbble</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="997"/>
+        <location filename="../application/displaycontent.cpp" line="1016"/>
+        <location filename="../application/logbackend.cpp" line="1460"/>
         <source>Date and Time</source>
         <translation type="unfinished"></translation>
     </message>
@@ -719,84 +783,84 @@
 <context>
     <name>Tree</name>
     <message>
-        <location filename="../application/loglistview.cpp" line="156"/>
-        <location filename="../application/loglistview.cpp" line="158"/>
+        <location filename="../application/loglistview.cpp" line="157"/>
+        <location filename="../application/loglistview.cpp" line="159"/>
         <source>System Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../application/loglistview.cpp" line="168"/>
         <location filename="../application/loglistview.cpp" line="170"/>
-        <location filename="../application/loglistview.cpp" line="179"/>
-        <location filename="../application/loglistview.cpp" line="181"/>
+        <location filename="../application/loglistview.cpp" line="178"/>
+        <location filename="../application/loglistview.cpp" line="180"/>
         <source>Kernel Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../application/loglistview.cpp" line="189"/>
         <location filename="../application/loglistview.cpp" line="191"/>
-        <location filename="../application/loglistview.cpp" line="193"/>
-        <location filename="../application/loglistview.cpp" line="201"/>
-        <location filename="../application/loglistview.cpp" line="203"/>
+        <location filename="../application/loglistview.cpp" line="198"/>
+        <location filename="../application/loglistview.cpp" line="200"/>
         <source>Boot Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="212"/>
-        <location filename="../application/loglistview.cpp" line="214"/>
+        <location filename="../application/loglistview.cpp" line="208"/>
+        <location filename="../application/loglistview.cpp" line="210"/>
         <source>dnf Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="223"/>
-        <location filename="../application/loglistview.cpp" line="225"/>
+        <location filename="../application/loglistview.cpp" line="218"/>
+        <location filename="../application/loglistview.cpp" line="220"/>
         <source>dpkg Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="246"/>
-        <location filename="../application/loglistview.cpp" line="248"/>
+        <location filename="../application/loglistview.cpp" line="239"/>
+        <location filename="../application/loglistview.cpp" line="241"/>
         <source>Xorg Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="273"/>
-        <location filename="../application/loglistview.cpp" line="275"/>
+        <location filename="../application/loglistview.cpp" line="264"/>
+        <location filename="../application/loglistview.cpp" line="266"/>
         <source>Coredump Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="300"/>
-        <location filename="../application/loglistview.cpp" line="302"/>
+        <location filename="../application/loglistview.cpp" line="289"/>
+        <location filename="../application/loglistview.cpp" line="291"/>
         <source>Other Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="318"/>
-        <location filename="../application/loglistview.cpp" line="320"/>
+        <location filename="../application/loglistview.cpp" line="306"/>
+        <location filename="../application/loglistview.cpp" line="308"/>
         <source>Audit Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="338"/>
-        <location filename="../application/loglistview.cpp" line="342"/>
+        <location filename="../application/loglistview.cpp" line="325"/>
+        <location filename="../application/loglistview.cpp" line="329"/>
         <source>Custom Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="236"/>
-        <location filename="../application/loglistview.cpp" line="238"/>
+        <location filename="../application/loglistview.cpp" line="230"/>
+        <location filename="../application/loglistview.cpp" line="232"/>
         <source>Kwin Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="259"/>
-        <location filename="../application/loglistview.cpp" line="262"/>
+        <location filename="../application/loglistview.cpp" line="251"/>
+        <location filename="../application/loglistview.cpp" line="254"/>
         <source>Application Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/loglistview.cpp" line="286"/>
-        <location filename="../application/loglistview.cpp" line="290"/>
+        <location filename="../application/loglistview.cpp" line="276"/>
+        <location filename="../application/loglistview.cpp" line="280"/>
         <source>Boot-Shutdown Event</source>
         <translation type="unfinished"></translation>
     </message>
@@ -804,7 +868,7 @@
 <context>
     <name>Waring</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="110"/>
+        <location filename="../application/displaycontent.cpp" line="117"/>
         <source>Unable to obtain crash information, please install systemd-coredump.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -812,13 +876,13 @@
 <context>
     <name>Warning</name>
     <message>
-        <location filename="../application/displaycontent.cpp" line="104"/>
+        <location filename="../application/displaycontent.cpp" line="111"/>
         <source>Security level for the current system: high
  audit only administrators can view the audit log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/displaycontent.cpp" line="2276"/>
+        <location filename="../application/displaycontent.cpp" line="2307"/>
         <source>You do not have permission to view it</source>
         <translation type="unfinished"></translation>
     </message>
@@ -826,51 +890,128 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../application/main.cpp" line="39"/>
-        <source>export logs</source>
+        <location filename="../application/main.cpp" line="58"/>
+        <source>Export logs to the specified path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/main.cpp" line="42"/>
-        <source>export logs directory. if not set, default export to ~/Document.</source>
+        <location filename="../application/main.cpp" line="58"/>
+        <source>PATH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="59"/>
+        <source>Export logs of specified types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="59"/>
+        <source>TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="60"/>
+        <source>Export logs of specified self-developed applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="60"/>
+        <source>SELF APPNAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="61"/>
+        <source>Export logs within a specified time period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="61"/>
+        <source>PERIOD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="62"/>
+        <source>Export logs within a specified debug level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="62"/>
+        <source>LEVEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="63"/>
+        <source>Export boot(no-klu) logs within a specified status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="63"/>
+        <source>BOOT STATUS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="64"/>
+        <source>Export boot-shutdown-event or audit logs within a specified event type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="64"/>
+        <source>EVENT TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="65"/>
+        <source>Export logs based on keywords search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="65"/>
+        <source>KEY WORD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application/main.cpp" line="66"/>
+        <source>Report coredump informations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>titlebar</name>
     <message>
-        <location filename="../application/logcollectormain.cpp" line="179"/>
+        <location filename="../application/logcollectormain.cpp" line="184"/>
         <source>Refresh interval</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logcollectormain.cpp" line="180"/>
+        <location filename="../application/logcollectormain.cpp" line="186"/>
         <source>10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logcollectormain.cpp" line="181"/>
+        <location filename="../application/logcollectormain.cpp" line="187"/>
         <source>1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logcollectormain.cpp" line="182"/>
+        <location filename="../application/logcollectormain.cpp" line="188"/>
         <location filename="../tests/src/ut_logcollectormain.cpp" line="322"/>
         <source>5 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logcollectormain.cpp" line="183"/>
+        <location filename="../application/logcollectormain.cpp" line="189"/>
         <source>No refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logcollectormain.cpp" line="210"/>
+        <location filename="../application/logcollectormain.cpp" line="216"/>
+        <location filename="../application/logcollectormain.cpp" line="217"/>
         <source>Export All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../application/logcollectormain.cpp" line="215"/>
+        <location filename="../application/logcollectormain.cpp" line="222"/>
+        <location filename="../application/logcollectormain.cpp" line="223"/>
         <source>Refresh Now</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
   Add a white list to check the export path
   white list include:
   1.current login user home path
   2./tmp dir
   3.device mount path
   4.smb path

Log: Fix security vulnerabilities introduced by LD_PRELOAD 2nd
Bug: https://pms.uniontech.com/bug-view-234125.html