### PR TITLE
fix: Fix the issue of filter option filtering without content when there is only one submodule

### DIFF
--- a/application/logfileparser.cpp
+++ b/application/logfileparser.cpp
@@ -310,6 +310,7 @@ int LogFileParser::parseByApp(const APP_FILTERS &iAPPFilter)
         else
             appFilter.submodule = appLogConfig.subModules[0].name;
         appFilter.logType = appLogConfig.subModules[0].logType;
+        appFilter.filter = appLogConfig.subModules[0].filter;
         appFilter.path = appLogConfig.subModules[0].logPath;
         appFilter.execPath = appLogConfig.subModules[0].execPath;
         appFilterList.push_back(appFilter);


### PR DESCRIPTION

  Fix the issue of filter option filtering without content when there is only one submodule

Log: Fix the issue of filter option filtering without content when there is only one submodule
Bug: https://pms.uniontech.com/bug-view-244901.html