### PR TITLE
feat: kwin crash log buried point report

### DIFF
--- a/application/configs/coredump-reporter.timer
+++ b/application/configs/coredump-reporter.timer
@@ -3,8 +3,8 @@ Description=deepin-log-viewer coredump report timer
 
 [Timer]
 Unit=coredump-reporter.service
-OnUnitActiveSec=24h
-OnBootSec=30m
+OnUnitActiveSec=30s
+OnBootSec=30s
 
 [Install]
 WantedBy=timers.target

--- a/application/logauththread.h
+++ b/application/logauththread.h
@@ -112,6 +112,9 @@ public slots:
     //    void onFinished(int exitCode);
     //    void kernDataRecived();
 private:
+    QString readAppLogFromLastLines(const QString& filePath, const int& count);
+
+private:
 
     QStringList m_list;
     QString m_output;

--- a/application/structdef.h
+++ b/application/structdef.h
@@ -234,6 +234,7 @@ struct LOG_MSG_COREDUMP {
     QString maps;
     QString packgeVersion;
     QString binaryInfo;
+    QString appLog;// 存放应用发生崩溃之前产生的应用日志
 
     QJsonObject toJson() {
         QJsonObject obj;
@@ -249,6 +250,8 @@ struct LOG_MSG_COREDUMP {
         }
         obj.insert("packageVersion", packgeVersion);
         obj.insert("binaryInfo", binaryInfo);
+        if (!appLog.isEmpty())
+            obj.insert("appLog", appLog);
 
         return obj;
     }

--- a/application/utils.cpp
+++ b/application/utils.cpp
@@ -350,7 +350,24 @@ QString Utils::getUserNamebyUID(uint uid)
 {
     struct passwd * pwd;
     pwd = getpwuid(uid);
+    if (nullptr == pwd) {
+        qCWarning(logUtils) << QString("unknown uid:%1").arg(uid);
+        return "";
+    }
+
     return pwd->pw_name;
+}
+
+QString Utils::getUserHomePathByUID(uint uid)
+{
+    struct passwd * pwd;
+    pwd = getpwuid(uid);
+    if (nullptr == pwd) {
+        qCWarning(logUtils) << QString("unknown uid:%1").arg(uid);
+        return "";
+    }
+
+    return pwd->pw_dir;
 }
 
 QString Utils::getCurrentUserName()

--- a/application/utils.h
+++ b/application/utils.h
@@ -62,6 +62,7 @@ public:
     static QString auditType(const QString& eventType);
     static double convertToMB(quint64 cap, const int size = 1024);
     static QString getUserNamebyUID(uint uid);  //根据uid获取用户名
+    static QString getUserHomePathByUID(uint uid); //根据uid获取用户家目录
     static QString getCurrentUserName();
     static bool isValidUserName(const QString &userName);
     static bool isCoredumpctlExist();  // is coredumpctl installed


### PR DESCRIPTION
    1.When kwin/Xwayland crash, report the last 100 lines log.
    2.To ensure the timeliness of kwin.log, the crash reporting task
       has been adjusted to be triggered every 30 seconds

Log: kwin crash log buried point report
Task: https://pms.uniontech.com/task-view-330013.html