### PR TITLE
fix: 修复在32位操作系统上使用64位time_t构建失败

### DIFF
--- a/application/wtmpparse.cpp
+++ b/application/wtmpparse.cpp
@@ -154,7 +154,7 @@ utmp list_get_ele_and_del(QList<utmp > &list, char *value, int &rs)
     return temp;
 }
 
-char *show_end_time(long timeval)
+char *show_end_time(time_t timeval)
 {
     struct tm *t;
     char tt[256] = {0};
@@ -165,7 +165,7 @@ char *show_end_time(long timeval)
     return asctime(t);
 }
 
-char *show_start_time(long timeval)
+char *show_start_time(time_t timeval)
 {
     struct tm *t;
     char tt[256] = {0};

--- a/application/wtmpparse.h
+++ b/application/wtmpparse.h
@@ -48,9 +48,9 @@ void list_insert(QList<utmp *> &plist, struct utmp *value);
 
 utmp list_get_ele_and_del(QList<utmp > &list, char *value, int &rs);
 
-char *show_end_time(long timeval);
+char *show_end_time(time_t timeval);
 
-char *show_start_time(long timeval);
+char *show_start_time(time_t timeval);
 
 void show_base_info(struct utmp *uBuf);
 


### PR DESCRIPTION
修复在32位操作系统上使用64位time_t构建失败

Bug: https://pms.uniontech.com/bug-view-250313.html
Log: 修复在32位操作系统上使用64位time_t构建失败