### PR TITLE
feat: Crash report content optimization

### DIFF
--- a/application/configs/dconfig/org.deepin.log.viewer.json
+++ b/application/configs/dconfig/org.deepin.log.viewer.json
@@ -22,6 +22,16 @@
             "permissions": "readwrite",
             "visibility": "private"
         },
+       "coredumpReportMax": {
+            "value": 50,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Coredump report max",
+            "name[zh_CN]": "一次上报的崩溃信息最大条数",
+            "description": "The maximum number of crash messages reported at once",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
 	"specialComType": {
             "value": -1,
             "serial": 0,

--- a/application/dbusproxy/dldbushandler.cpp
+++ b/application/dbusproxy/dldbushandler.cpp
@@ -141,3 +141,8 @@ qint64 DLDBusHandler::getLineCount(const QString &filePath)
 {
     return m_dbus->getLineCount(filePath);
 }
+
+QString DLDBusHandler::executeCmd(const QString &cmd)
+{
+    return m_dbus->executeCmd(cmd);
+}

--- a/application/dbusproxy/dldbushandler.h
+++ b/application/dbusproxy/dldbushandler.h
@@ -24,6 +24,7 @@ public:
     bool isFileExist(const QString &filePath);
     quint64 getFileSize(const QString &filePath);
     qint64 getLineCount(const QString &filePath);
+    QString executeCmd(const QString &cmd);
     QString openLogStream(const QString &filePath);
     QString readLogInStream(const QString &token);
     QStringList whiteListOutPaths();

--- a/application/dbusproxy/dldbusinterface.h
+++ b/application/dbusproxy/dldbusinterface.h
@@ -120,6 +120,13 @@ public Q_SLOTS: // METHODS
         return asyncCallWithArgumentList(QStringLiteral("getLineCount"), argumentList);
     }
 
+    inline QDBusPendingReply<QString> executeCmd(const QString &cmd)
+    {
+        QList<QVariant> argumentList;
+        argumentList << QVariant::fromValue(cmd);
+        return asyncCallWithArgumentList(QStringLiteral("executeCmd"), argumentList);
+    }
+
     inline QDBusPendingReply<QStringList> whiteListOutPaths()
     {
         QList<QVariant> argumentList;

--- a/application/displaycontent.cpp
+++ b/application/displaycontent.cpp
@@ -3061,7 +3061,7 @@ void DisplayContent::parseListToModel(QList<LOG_MSG_COREDUMP> iList, QStandardIt
         item->setAccessibleText(QString("treeview_context_%1_%2").arg(i).arg(2));
         items << item;
 
-        item = new DStandardItem(iList[i].uid);
+        item = new DStandardItem(iList[i].userName);
         item->setData(COREDUMP_TABLE_DATA);
         item->setAccessibleText(QString("treeview_context_%1_%2").arg(i).arg(3));
         items << item;

--- a/application/gschema/com.deepin.log.viewer.gschema.xml
+++ b/application/gschema/com.deepin.log.viewer.gschema.xml
@@ -13,5 +13,11 @@
             <summary>Coredump report time</summary>
             <description>It is null by default. Record the time point of the last successful crash report, used to achieve incremental escalation</description>
         </key>
+        <key type="i" name="coredumpreportmax">
+            <range min="0" max="1000" />
+            <default>50</default>
+            <summary>Coredump report max</summary>
+            <description>It is 50 by default.The maximum number of crash messages reported at once</description>
+        </key>
     </schema>
 </schemalist>

--- a/application/logapplicationhelper.cpp
+++ b/application/logapplicationhelper.cpp
@@ -29,8 +29,14 @@ const QString APP_LOG_CONFIG_PATH = "/usr/share/deepin-log-viewer/deepin-log.con
 
 const QString COREDUMP_REPORT_TIME = "coredumpReportTime";
 const QString COREDUMP_REPORT_TIME_GSETTING = "coredumpreporttime";
+const QString COREDUMP_REPORT_MAX = "coredumpReportMax";
+const QString COREDUMP_REPORT_MAX_GSETTING = "coredumpreportmax";
 const QString DCONFIG_APPID = "org.deepin.log.viewer";
 const QString GSETTING_APPID = "com.deepin.log.viewer";
+
+// 默认崩溃上报最大条数
+#define MAX_COREDUMP_REPORT 50
+
 /**
  * @brief LogApplicationHelper::LogApplicationHelper 构造函数，获取日志文件路径和应用名称
  * @param parent 父对象
@@ -772,6 +778,22 @@ void LogApplicationHelper::saveLastRerportTime(const QDateTime &date)
     if (m_pGSettings)
         m_pGSettings->set(COREDUMP_REPORT_TIME_GSETTING, str);
 #endif
+}
+
+int LogApplicationHelper::getMaxReportCoredump()
+{
+    QVariant value(MAX_COREDUMP_REPORT);
+
+#ifdef DTKCORE_CLASS_DConfigFile
+    value = m_pDConfig->value(COREDUMP_REPORT_MAX);
+#else
+    if (m_pGSettings) {
+        time = m_pGSettings->get(COREDUMP_REPORT_MAX_GSETTING);
+    }
+#endif
+
+    qCWarning(logAppHelper) << "coredump report max:" << value.toInt();
+    return value.toInt();
 }
 
 //从应用包名转换为应用显示文本

--- a/application/logapplicationhelper.h
+++ b/application/logapplicationhelper.h
@@ -67,6 +67,8 @@ public:
 
     QDateTime getLastReportTime();
     void saveLastRerportTime(const QDateTime& date);
+    // 获取崩溃上报最大条数，默认为50
+    int getMaxReportCoredump();
 
 private:
     explicit LogApplicationHelper(QObject *parent = nullptr);

--- a/application/logbackend.h
+++ b/application/logbackend.h
@@ -241,6 +241,7 @@ private:
     QString getApplogPath(const QString &appName);
     QStringList getLabels(const LOG_FLAG &flag);
     bool hasMatchedData(const LOG_FLAG &flag);
+    void parseCoredumpDetailInfo(QList<LOG_MSG_COREDUMP>& list);
 
 private:
     QStringList m_logTypes;

--- a/application/structdef.h
+++ b/application/structdef.h
@@ -229,6 +229,7 @@ struct LOG_MSG_COREDUMP {
     QString dateTime;
     QString coreFile;
     QString uid;
+    QString userName;
     QString exe;
     QString pid;
     QString storagePath;

--- a/application/utils.h
+++ b/application/utils.h
@@ -14,6 +14,13 @@
 
 #include <QObject>
 #include <QHash>
+
+struct LOG_REPEAT_COREDUMP_INFO {
+    QString exePath = "";
+    int times = 1; // 出现次数
+    float repetitionRate = 0.0;
+};
+
 /**
  * @brief 公用工具静态函数类
  */
@@ -69,6 +76,12 @@ public:
     static QString getHomePath(const QString &userName = "");
     static QString appName(const QString &filePath);
     static void resetToNormalAuth(const QString &path);
+    // 统计所有崩溃记录重复次数
+    static QList<LOG_REPEAT_COREDUMP_INFO> countRepeatCoredumps(qint64 timeBegin = -1, qint64 timeEnd = -1);
+    // 获取高频重复崩溃记录exe路径名单
+    static QStringList getRepeatCoredumpExePaths();
+    // 更新高频重复崩溃记录exe路径到文件
+    static void updateRepeatCoredumpExePaths(const QList<LOG_REPEAT_COREDUMP_INFO> &infos = QList<LOG_REPEAT_COREDUMP_INFO>());
     /**
      * @brief specialComType 是否是特殊机型，like huawei
      * 取值有3种（-1,0,>0），默认为-1（未知），0（不是特殊机型）,>0（特殊机型）

--- a/logViewerService/assets/data/com.deepin.logviewer.xml
+++ b/logViewerService/assets/data/com.deepin.logviewer.xml
@@ -47,6 +47,10 @@
       <arg type="x" direction="out"/>
       <arg name="filePath" type="s" direction="in"/>
     </method>
+    <method name="executeCmd"> 
+      <arg type="s" direction="out"/>
+      <arg name="cmd" type="s" direction="in"/>
+    </method>
     <method name="whiteListOutPaths">
       <arg type="as" direction="out"/>
     </method>

--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -34,6 +34,9 @@ Q_LOGGING_CATEGORY(logService, "org.deepin.log.viewer.service")
 Q_LOGGING_CATEGORY(logService, "org.deepin.log.viewer.service", QtInfoMsg)
 #endif
 
+// 读取崩溃应用maps信息最大行数
+#define COREDUMP_MAPS_MAX_LINES 200
+
 /**
    @brief 移除路径 \a dirPath 下的文件，注意，不会递归删除文件夹
  */
@@ -147,7 +150,20 @@ QString LogViewerService::readLog(const QString &filePath)
         m_process.start("/bin/bash", QStringList() << "-c" << filePath);
         m_process.waitForFinished(-1);
 
-        return m_process.readAllStandardOutput();
+        // 因原始maps信息过大，基本几百KB，埋点平台并不需要全量数据，仅取前200行maps信息即可
+        QTextStream in(m_process.readAllStandardOutput());
+        QStringList lines;
+        QString str;
+        while (!in.atEnd()) {
+            str  = in.readLine();
+
+            if (!str.isEmpty())
+                lines.push_back(str);
+            if (lines.count() >= COREDUMP_MAPS_MAX_LINES)
+                break;
+        }
+
+        return lines.join('\n').toUtf8();
     } else {
         m_process.start("cat", QStringList() << filePath);
         m_process.waitForFinished(-1);
@@ -306,6 +322,29 @@ qint64 LogViewerService::getLineCount(const QString &filePath) {
         lineCount = splitResult.first().toLongLong();
 
     return lineCount;
+}
+
+QString LogViewerService::executeCmd(const QString &cmd)
+{
+    QString result("");
+
+    if (!isValidInvoker())
+        return result;
+
+    QString validCmd;
+    if (cmd == "coredumpctl-list-count")
+        validCmd = "coredumpctl list | wc -l";
+    else if (cmd == "coredumpctl-list")
+        validCmd = "coredumpctl list";
+
+    if (!validCmd.isEmpty()) {
+        m_process.start("/bin/bash", QStringList() << "-c" << validCmd);
+        m_process.waitForFinished(-1);
+
+        result = m_process.readAllStandardOutput();
+    }
+
+    return result;
 }
 
 /*!

--- a/logViewerService/logviewerservice.h
+++ b/logViewerService/logviewerservice.h
@@ -40,6 +40,8 @@ public Q_SLOTS:
     Q_SCRIPTABLE bool isFileExist(const QString &filePath);
     Q_SCRIPTABLE quint64 getFileSize(const QString &filePath);
     Q_SCRIPTABLE qint64 getLineCount(const QString &filePath);
+    // 仅能执行特定合法命令
+    Q_SCRIPTABLE QString executeCmd(const QString &cmd);
     Q_SCRIPTABLE QStringList whiteListOutPaths();
 
 public:


### PR DESCRIPTION
   Crash report content optimization
   1.add key of coredumpListCount: Record the number of query results for the ‘sudo coredumpctl list’ command;
   2.add key of repeatCoredumps: Record the number of times crash information appears in different time ranges from the last reported time node to the current time node;
   3.Definition of high-frequency crash application: The number of crashes accounts for more than 80% of the total number of newly added crashes, or occurs more than 3 times repeatedly;
   4.Add the coredumpReportMax(default to 50) parameter configuration in Dconfig/Gsettings to limit the maximum number of entries per report;
   6.About coredump detail infos, such as maps info, only report the first 200 rows;
   7.Analyze the business code of crash details information and trigger it when adjusting to the ready burial point.

Log: Crash report content optimization
Task: https://pms.uniontech.com/task-view-343581.html