### PR TITLE
feat: adapt treeland and fix error

### DIFF
--- a/application/logauththread.cpp
+++ b/application/logauththread.cpp
@@ -1207,8 +1207,9 @@ void LogAuthThread::handleCoredump()
         }
 
         // 获取信号名称
-        int sigId = tmpList[7].toInt();
-        if ( sigId <= sigList.size()) {
+        bool isOk = false;
+        int sigId = tmpList[7].toInt(&isOk);
+        if (isOk && sigId >= 1 && sigId <= sigList.size()) {
             coredumpMsg.sig = sigList[sigId - 1];
         } else {
             coredumpMsg.sig = tmpList[7];

--- a/application/main.cpp
+++ b/application/main.cpp
@@ -295,8 +295,7 @@ int main(int argc, char *argv[])
         //klu下不使用opengl 使用OpenGLES,因为opengl基于x11 现在全面换wayland了
         QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
         //klu下不使用opengl 使用OpenGLES,因为opengl基于x11 现在全面换wayland了,这个真正有效
-        qputenv("QT_WAYLAND_SHELL_INTEGRATION", "kwayland-shell");
-        if (Utils::isWayland()) {
+        if (Utils::isWayland() && !Utils::isTreeland()) {
             qputenv("QT_WAYLAND_SHELL_INTEGRATION", "kwayland-shell");
         }
         setenv("PULSE_PROP_media.role", "video", 1);

--- a/application/utils.cpp
+++ b/application/utils.cpp
@@ -274,6 +274,11 @@ bool Utils::isWayland()
     }
 }
 
+bool Utils::isTreeland()
+{
+    return qEnvironmentVariable("DDE_CURRENT_COMPOSITOR") == QStringLiteral("TreeLand");
+}
+
 bool Utils::sleep(unsigned int msec)
 {
     QTime dieTime = QTime::currentTime().addMSecs(static_cast<int>(msec));

--- a/application/utils.h
+++ b/application/utils.h
@@ -59,6 +59,7 @@ public:
     static bool deleteDir(const QString &iFilePath);
     static void replaceColorfulFont(QString *iStr);
     static bool isWayland();
+    static bool isTreeland();
     static bool sleep(unsigned int msec);
     //创建多级文件夹
     static QString mkMutiDir(const QString &path);


### PR DESCRIPTION
[feat: adapt treeland](https://github.com/linuxdeepin/deepin-log-viewer/commit/d39e6284c1616de637afaf0ad137dcceae3f83ee) 

Adapt Treeland, disable kwayland-shell in
Treeland enviroment.

Log: Adapt Treeland.
Influence: Treeland

[fix: out-of-bounds access error](https://github.com/linuxdeepin/deepin-log-viewer/commit/38280001c536c137f155766552f66696cbc67330) 

As title.

Log: Fix out-of-bounds access error