### PR TITLE
fix: isFileExist DBus interface return value handling logic

### DIFF
--- a/application/dbusproxy/dldbushandler.cpp
+++ b/application/dbusproxy/dldbushandler.cpp
@@ -165,13 +165,13 @@ bool DLDBusHandler::exportLog(const QString &outDir, const QString &in, bool isF
 
 bool DLDBusHandler::isFileExist(const QString &filePath)
 {
-    QDBusPendingReply<bool> reply = m_dbus->isFileExist(filePath);
+    QDBusPendingReply<QString> reply = m_dbus->isFileExist(filePath);
     reply.waitForFinished();
     bool bRet = false;
     if (reply.isError()) {
         qCWarning(logDBusHandler) << "call dbus iterface 'isFileExist()' failed. error info:" << reply.error().message();
     } else {
-        bRet = reply.value();
+        bRet = (reply.value() == "exist");
     }
     return bRet;
 }


### PR DESCRIPTION
DBus interface returns QString type, but the frontend receives it as bool, causing continuous error logic.

Log: fix <can`t open audit log by deepin-log-viewer>

Bug: https://pms.uniontech.com/bug-view-302415.html