### PR TITLE
chore: remove libdframeworkdbus-dev dependency

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -14,7 +14,7 @@ Copyright: None
 License: CC0-1.0
 
 # xml toml json conf yaml sh
-Files: *.toml *.json *conf *.yaml *.sh *.h.in
+Files: *.toml *.json *conf *.yaml *.sh *.h.in .project
 Copyright: UnionTech Software Technology Co., Ltd.
 License: CC0-1.0
 

--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,6 @@ Build-Depends:
  libpolkit-qt6-1-dev | libpolkit-qt5-1-dev,
  libsystemd-dev,
  libicu-dev,
- libdframeworkdbus-dev,
  libgtest-dev,
  libgmock-dev,
  libzip-dev,


### PR DESCRIPTION
- Remove unused build dependency from debian/control

Log: remove libdframeworkdbus-dev dependency