### PR TITLE
fix: log filtering and parsing logic

### DIFF
--- a/application/logbackend.cpp
+++ b/application/logbackend.cpp
@@ -1279,31 +1279,20 @@ QList<LOG_MSG_APPLICATOIN> LogBackend::filterApp(APP_FILTERS appFilter, const QL
         return iList;
     }
 
-    if (appFilter.submodule.isEmpty()) {
-        for (int i = 0; i < iList.size(); i++) {
-            LOG_MSG_APPLICATOIN msg = iList.at(i);
-            if (msg.dateTime.contains(appFilter.searchstr, Qt::CaseInsensitive)
-                    || msg.level.contains(appFilter.searchstr, Qt::CaseInsensitive)
-                    || msg.src.contains(appFilter.searchstr, Qt::CaseInsensitive)
-                    || msg.msg.contains(appFilter.searchstr, Qt::CaseInsensitive)
-                    || msg.subModule.contains(appFilter.searchstr, Qt::CaseInsensitive)) {
+    for (int i = 0; i < iList.size(); i++) {
+        LOG_MSG_APPLICATOIN msg = iList.at(i);
+        if (msg.subModule == "" && !appFilter.submodule.isEmpty())
+            continue;
+        if (msg.dateTime.contains(appFilter.searchstr, Qt::CaseInsensitive)
+            || msg.level.contains(appFilter.searchstr, Qt::CaseInsensitive)
+            || msg.src.contains(appFilter.searchstr, Qt::CaseInsensitive)
+            || msg.msg.contains(appFilter.searchstr, Qt::CaseInsensitive)
+            || msg.subModule.contains(appFilter.searchstr, Qt::CaseInsensitive)) {
+            if (appFilter.submodule.isEmpty() || msg.subModule.compare(appFilter.submodule, Qt::CaseInsensitive) == 0)
                 rsList.append(msg);
-            }
-        }
-    } else {
-        for (int i = 0; i < iList.size(); i++) {
-            LOG_MSG_APPLICATOIN msg = iList.at(i);
-            if (msg.dateTime.contains(appFilter.searchstr, Qt::CaseInsensitive)
-                    || msg.level.contains(appFilter.searchstr, Qt::CaseInsensitive)
-                    || msg.src.contains(appFilter.searchstr, Qt::CaseInsensitive)
-                    || msg.msg.contains(appFilter.searchstr, Qt::CaseInsensitive)
-                    || msg.subModule.contains(appFilter.searchstr, Qt::CaseInsensitive)) {
-                if (msg.subModule.compare(appFilter.submodule, Qt::CaseInsensitive) == 0) {
-                    rsList.append(msg);
-                }
-            }
         }
     }
+
     return rsList;
 }
 

--- a/application/logfileparser.cpp
+++ b/application/logfileparser.cpp
@@ -262,6 +262,15 @@ int LogFileParser::parseByApp(const APP_FILTERS &iAPPFilter)
         appFilter.execPath = appLogConfig.subModules[0].execPath;
         appFilterList.push_back(appFilter);
     } else if (appLogConfig.subModules.size() > 1) {
+        // 使用一个空的filter获取没有设置子模块的日志
+        APP_FILTERS defaultFilter = iAPPFilter;
+        defaultFilter.submodule = "";
+        defaultFilter.filter = "";
+        // 使用file类型日志但没有设置日志路径，使用journalCtl尝试获取
+        if (defaultFilter.path.isEmpty() && defaultFilter.logType == "file")
+            defaultFilter.logType = "journal";
+        appFilterList.push_back(defaultFilter);
+
         for (auto submodule : appLogConfig.subModules) {
             APP_FILTERS appFilter = iAPPFilter;
             appFilter.submodule = submodule.name;


### PR DESCRIPTION
    - Combine duplicate filtering logic in logbackend.cpp into single more efficient implementation
    - Add default filter case in logfileparser.cpp to handle logs without submodules
    - Improve submodule filtering consistency across both files

log: as title

Bug: https://pms.uniontech.com/bug-view-309739.html