### PR TITLE
refactor: Remove isValidUserName and getHomePath functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ build/
 CMakeFiles/
 cmake_install.cmake
 CMakeCache.txt
+
+# AI
+.cursor
+.specstory

--- a/application/utils.cpp
+++ b/application/utils.cpp
@@ -411,23 +411,6 @@ QString Utils::getCurrentUserName()
     return pwd->pw_name;
 }
 
-bool Utils::isValidUserName(const QString &userName)
-{
-    bool bValidUserName = false;
-    QDBusInterface interface("com.deepin.daemon.Accounts", "/com/deepin/daemon/Accounts", "com.deepin.daemon.Accounts", QDBusConnection::systemBus());
-    QStringList userList = qvariant_cast< QStringList >(interface.property("UserList"));
-    for (auto strUser : userList) {
-        uint uid = strUser.mid(strUser.lastIndexOf("User") + 4).toUInt();
-        QString tempUserName = getUserNamebyUID(uid);
-        if(tempUserName == userName) {
-            bValidUserName = true;
-            break;
-        }
-    }
-
-    return bValidUserName;
-}
-
 bool Utils::isCoredumpctlExist()
 {
     qCDebug(logUtils) << "Checking if coredumpctl exists";
@@ -445,34 +428,6 @@ bool Utils::isCoredumpctlExist()
     
     qCDebug(logUtils) << "coredumpctl exists:" << isCoredumpctlExist;
     return isCoredumpctlExist;
-}
-
-QString Utils::getHomePath(const QString &userName)
-{
-    QString uName("");
-    if (!userName.isEmpty())
-        uName = userName;
-    else
-        uName = getCurrentUserName();
-
-    QString homePath = "";
-    if (isValidUserName(uName)) {
-        QProcess *unlock = new QProcess;
-        unlock->start("sh", QStringList() << "-c" << QString("cat /etc/passwd | grep %1").arg(uName));
-        unlock->waitForFinished();
-        auto output = unlock->readAllStandardOutput();
-        auto str = QString::fromUtf8(output);
-        homePath = str.mid(str.indexOf("::") + 2).split(":").first();
-    }
-
-    // 根据用户名获取家目录失败，默认采用QDir::homePath()作为homePath
-    QDir dir(homePath);
-    if (!dir.exists() || homePath.isEmpty())
-        homePath = QDir::homePath();
-
-    qCDebug(logUtils) << "userName: " << uName << "homePath:" << homePath;
-
-    return homePath;
 }
 
 QString Utils::appName(const QString &filePath)

--- a/application/utils.h
+++ b/application/utils.h
@@ -71,9 +71,7 @@ public:
     static QString getUserNamebyUID(uint uid);  //根据uid获取用户名
     static QString getUserHomePathByUID(uint uid); //根据uid获取用户家目录
     static QString getCurrentUserName();
-    static bool isValidUserName(const QString &userName);
     static bool isCoredumpctlExist();  // is coredumpctl installed
-    static QString getHomePath(const QString &userName = "");
     static QString appName(const QString &filePath);
     static void resetToNormalAuth(const QString &path);
     // 统计所有崩溃记录重复次数


### PR DESCRIPTION
- Deleted the isValidUserName and getHomePath functions from utils.cpp and utils.h as they were not utilized in the codebase.
- Updated .gitignore to include new AI-related files.

Log: Adapt to V23 dde dbus interface