### PR TITLE
 fix: Update log viewer titles for consistency     

### DIFF
--- a/application/assets/deepin-log-viewer/log-viewer/en_US/log-viewer.md
+++ b/application/assets/deepin-log-viewer/log-viewer/en_US/log-viewer.md
@@ -1,4 +1,4 @@
-# Log Viewer | deepin-log-viewer
+# Log Viewer|deepin-log-viewer|
 ## Overview
 The Log Collection Tool is a utility designed to gather logs generated during program execution, including information about operating system and application startup, operation, and other processes. By analyzing detailed log information, you can quickly identify the cause of issues and resolve them.
 ## Getting Started

--- a/application/assets/deepin-log-viewer/log-viewer/zh_CN/log-viewer.md
+++ b/application/assets/deepin-log-viewer/log-viewer/zh_CN/log-viewer.md
@@ -1,4 +1,4 @@
-# 日志收集工具 | deepin-log-viewer
+# 日志收集工具|deepin-log-viewer|
 
 ## 概述
 

--- a/application/assets/deepin-log-viewer/log-viewer/zh_HK/log-viewer.md
+++ b/application/assets/deepin-log-viewer/log-viewer/zh_HK/log-viewer.md
@@ -1,4 +1,4 @@
-# 日誌收集工具 | deepin-log-viewer
+# 日誌收集工具|deepin-log-viewer|
 
 ## 概述
 

--- a/application/assets/deepin-log-viewer/log-viewer/zh_TW/log-viewer.md
+++ b/application/assets/deepin-log-viewer/log-viewer/zh_TW/log-viewer.md
@@ -1,4 +1,4 @@
-# 日誌收集工具 | deepin-log-viewer
+# 日誌收集工具 |deepin-log-viewer|
 
 ## 概述
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-log-viewer (6.5.14) unstable; urgency=medium
+
+  * chore: Add compile flags for deepin-log-viewer
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 19 Jun 2025 21:50:45 +0800
+
 deepin-log-viewer (6.5.13) unstable; urgency=medium
 
   * add compile flags.  


### PR DESCRIPTION
 fix: Update log viewer titles for consistency
    
    - Removed spaces around the pipe symbol in the titles of log-viewer markdown files for en_US, zh_CN, zh_HK, and zh_TW to ensure uniformity across different language versions.
    
    bug: https://pms.uniontech.com/bug-view-321185.html
