### PR TITLE
fix: rework log export mechanism to use direct zip streaming

### DIFF
--- a/application/logallexportthread.cpp
+++ b/application/logallexportthread.cpp
@@ -8,22 +8,178 @@
 #include "utils.h"
 
 #include <QLoggingCategory>
+#include <QFileInfo>
+#include <QDir>
+#include <QProcess>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QDateTime>
+#include <QSet>
 
 Q_DECLARE_LOGGING_CATEGORY(logApp)
+
+constexpr int ZIP_BUFFER_SIZE = 64 * 1024; // 64KB buffer for better I/O performance
+constexpr int ZIP_COMPRESSION_LEVEL = Z_BEST_SPEED; // Fast compression for logs
+
+// Helper function to convert QDateTime to tm_zip structure
+static tm_zip dateTimeToTmZip(const QDateTime &dateTime)
+{
+    tm_zip tmz = {};
+    if (dateTime.isValid()) {
+        QDate date = dateTime.date();
+        QTime time = dateTime.time();
+        
+        tmz.tm_year = date.year();
+        tmz.tm_mon = date.month() - 1;  // tm_mon is 0-based (0-11)
+        tmz.tm_mday = date.day();
+        tmz.tm_hour = time.hour();
+        tmz.tm_min = time.minute();
+        tmz.tm_sec = time.second();
+    }
+    return tmz;
+}
 
 LogAllExportThread::LogAllExportThread(const QStringList &types, const QString &outfile, QObject *parent)
     : QObject(parent)
     , m_types(types)
     , m_outfile(outfile)
+    , m_cancel(false)
 {
     qCDebug(logApp) << "LogAllExportThread created with types:" << types << "output file:" << outfile;
 }
 
+bool LogAllExportThread::addFileToZip(const QString &filePath, const QString &zipEntryName)
+{
+    if (m_cancel.load() || !m_zipFile) return false;
+
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        qCWarning(logApp) << "Failed to open file for zipping:" << filePath;
+        return false;
+    }
+
+    // Get file modification time and set it in zip_fileinfo
+    zip_fileinfo zfi = {};
+    QFileInfo fileInfo(filePath);
+    if (fileInfo.exists()) {
+        QDateTime lastModified = fileInfo.lastModified();
+        zfi.tmz_date = dateTimeToTmZip(lastModified);
+        zfi.dosDate = 0; // Use tmz_date instead of dosDate
+    }
+    
+    zipOpenNewFileInZip64(m_zipFile, zipEntryName.toUtf8().constData(), &zfi, nullptr, 0, nullptr, 0, nullptr, Z_DEFLATED, ZIP_COMPRESSION_LEVEL, 1);
+
+    char buf[ZIP_BUFFER_SIZE];
+    qint64 bytesRead;
+    while ((bytesRead = file.read(buf, ZIP_BUFFER_SIZE)) > 0) {
+        if (m_cancel.load()) {
+            zipCloseFileInZip(m_zipFile);
+            return false;
+        }
+        if (zipWriteInFileInZip(m_zipFile, buf, bytesRead) != ZIP_OK) {
+            qCCritical(logApp) << "Failed to write to zip stream for file:" << filePath;
+            zipCloseFileInZip(m_zipFile);
+            return false;
+        }
+    }
+
+    zipCloseFileInZip(m_zipFile);
+    return true;
+}
+
+bool LogAllExportThread::addProcessOutputToZip(const QString &command, const QStringList &args, const QString &zipEntryName)
+{
+    if (m_cancel.load() || !m_zipFile) return false;
+
+    QProcess process;
+    process.start(command, args);
+    if (!process.waitForStarted()) {
+        qCWarning(logApp) << "Failed to start process for command:" << command << args;
+        return false;
+    }
+
+    // Set current time for process output
+    zip_fileinfo zfi = {};
+    QDateTime currentTime = QDateTime::currentDateTime();
+    zfi.tmz_date = dateTimeToTmZip(currentTime);
+    zfi.dosDate = 0; // Use tmz_date instead of dosDate
+    
+    zipOpenNewFileInZip64(m_zipFile, zipEntryName.toUtf8().constData(), &zfi, nullptr, 0, nullptr, 0, nullptr, Z_DEFLATED, ZIP_COMPRESSION_LEVEL, 1);
+
+    char buf[ZIP_BUFFER_SIZE];
+    while (process.waitForReadyRead(100)) {
+        if (m_cancel.load()) {
+            process.terminate();
+            zipCloseFileInZip(m_zipFile);
+            return false;
+        }
+        qint64 bytesRead = process.read(buf, ZIP_BUFFER_SIZE);
+        if (bytesRead > 0) {
+            if (zipWriteInFileInZip(m_zipFile, buf, bytesRead) != ZIP_OK) {
+                qCCritical(logApp) << "Failed to write process output to zip stream for command:" << command;
+                process.terminate();
+                zipCloseFileInZip(m_zipFile);
+                return false;
+            }
+        }
+    }
+
+    process.waitForFinished();
+    zipCloseFileInZip(m_zipFile);
+    return true;
+}
+
+void LogAllExportThread::ensureDirectoriesExist(const QString &filePath)
+{
+    if (m_cancel.load() || !m_zipFile) return;
+    
+    // Use static set to track created directories, clear on new zip file
+    static QSet<QString> createdDirs;
+    static zipFile lastZipFile = nullptr;
+    
+    // Clear directory tracking when starting a new export
+    if (m_zipFile != lastZipFile) {
+        createdDirs.clear();
+        lastZipFile = m_zipFile;
+    }
+    
+    // Extract directory parts from file path
+    QStringList pathParts = filePath.split('/', Qt::SkipEmptyParts);
+    if (pathParts.size() <= 1) return; // No directories to create
+    
+    QString currentPath;
+    for (int i = 0; i < pathParts.size() - 1; ++i) { // Exclude the filename
+        if (!currentPath.isEmpty()) {
+            currentPath += "/";
+        }
+        currentPath += pathParts[i];
+        
+        // Skip if directory already created
+        if (createdDirs.contains(currentPath)) {
+            continue;
+        }
+        
+        // Create directory entry with current time
+        zip_fileinfo zfi = {};
+        QDateTime currentTime = QDateTime::currentDateTime();
+        zfi.tmz_date = dateTimeToTmZip(currentTime);
+        zfi.dosDate = 0;
+        
+        // Directory names in ZIP should end with '/'
+        QString dirName = currentPath + '/';
+        
+        // Create empty directory entry
+        if (zipOpenNewFileInZip64(m_zipFile, dirName.toUtf8().constData(), &zfi, nullptr, 0, nullptr, 0, nullptr, Z_DEFLATED, ZIP_COMPRESSION_LEVEL, 1) == ZIP_OK) {
+            zipCloseFileInZip(m_zipFile);
+            createdDirs.insert(currentPath);
+        }
+    }
+}
+
 void LogAllExportThread::run()
 {
-    qCDebug(logApp) << "Export thread started";
-    //判断权限
-    qCInfo(logApp) << "outFile: " << m_outfile;
+    qCDebug(logApp) << "Export thread started with new zip stream logic";
+
     QFileInfo info(m_outfile);
     if (!QFileInfo(info.path()).isWritable()) {
         qCCritical(logApp) << QString("outdir:%1 it not writable or is not exist.").arg(info.absolutePath());
@@ -31,10 +187,24 @@ void LogAllExportThread::run()
         return;
     }
 
-    QList<EXPORTALL_DATA> eList;
+    if (info.exists() && !QFile::remove(m_outfile)) {
+        qCCritical(logApp) << "Failed to remove existing output file:" << m_outfile;
+        emit exportFinsh(false);
+        return;
+    }
 
-    int nCount = 0;
-    //获取所有文件
+    m_zipFile = zipOpen64(m_outfile.toUtf8().constData(), 0);
+    if (!m_zipFile) {
+        qCCritical(logApp) << "Failed to create zip file:" << m_outfile;
+        emit exportFinsh(false);
+        return;
+    }
+    emit updatecurrentProcess(1); //update process started
+
+    QList<EXPORTALL_DATA> eList;
+    int totalTasks = 0;
+
+    // --- Data Gathering (same as before) ---
     for (auto &it : m_types) {
         EXPORTALL_DATA data;
         if (it.contains(JOUR_TREE_DATA, Qt::CaseInsensitive)) {
@@ -124,131 +294,124 @@ void LogAllExportThread::run()
             data.files.append(DLDBusHandler::instance(nullptr)->getFileInfo("audit", false));
         }
 
-        eList.push_back(data);
         data.files.removeDuplicates();
         data.commands.removeDuplicates();
-        nCount += data.files.size() + data.commands.size() + data.dir2FilesCount() + data.dir2CmdsCount();
-
-        //取消导出直接返回
-        if (m_cancel) {
-            emit exportFinsh(false);
-            return;
-        }
+        totalTasks += data.files.size() + data.commands.size() + data.dir2FilesCount() + data.dir2CmdsCount();
+        eList.push_back(data);
     }
 
     if (eList.isEmpty()) {
         qCWarning(logApp) << "No log types specified for export";
+        zipClose(m_zipFile, nullptr);
+        QFile::remove(m_outfile);
         emit exportFinsh(false);
         return;
     }
 
-    //删除原文件
-    if (info.exists() && !QFile::remove(m_outfile)) {
-        qCCritical(logApp) << "Failed to remove existing output file:" << m_outfile;
-        emit exportFinsh(false);
-        return;
-    }
+    emit updateTolProcess(totalTasks);
+    int completedTasks = 0;
 
-    int tolProcess = nCount + 10;
-    int currentProcess = 1;
-    emit updateTolProcess(tolProcess);
-    QString tmpPath = Utils::getAppDataPath() + "/tmp/";
-    QDir dir(tmpPath);
-    //删除临时目录
-    dir.removeRecursively();
-    //创建临时目录
-    Utils::mkMutiDir(tmpPath);
-    for (auto &it : eList) {
-        qCDebug(logApp) << "Processing log category:" << it.logCategory;
-        //复制文件到一级目录
-        QString tmpCategoryPath = QString("%1%2/").arg(tmpPath).arg(it.logCategory);
-        Utils::mkMutiDir(tmpCategoryPath);
-        for (auto &file : it.files) {
-            DLDBusHandler::instance(this)->exportLog(tmpCategoryPath, file, true);
-            emit updatecurrentProcess(currentProcess++);
-            if (m_cancel) {
-                break;
+    // --- Processing Logic ---
+    for (auto &data : eList) {
+        if (m_cancel.load()) break;
+
+        // Files in category root
+        for (const auto &file : data.files) {
+            if (m_cancel.load()) break;
+            // Optimize: extract filename without constructing QFileInfo
+            int lastSlash = file.lastIndexOf('/');
+            QString fileName = (lastSlash >= 0) ? file.mid(lastSlash + 1) : file;
+            QString entryName = data.logCategory + '/' + fileName;
+            ensureDirectoriesExist(entryName);
+            if (!addFileToZip(file, entryName)) {
+                 qCWarning(logApp) << "Failed to add file to zip:" << file;
+            }
+            emit updatecurrentProcess(++completedTasks);
+        }
+        if (m_cancel.load()) break;
+
+        // Files in subdirectories
+        QMapIterator<QString, QStringList> fileMapIt(data.dir2Files);
+        while (fileMapIt.hasNext()) {
+            if (m_cancel.load()) break;
+            fileMapIt.next();
+            for (const auto &path : fileMapIt.value()) {
+                if (m_cancel.load()) break;
+                // Optimize: extract filename without constructing QFileInfo
+                int lastSlash = path.lastIndexOf('/');
+                QString fileName = (lastSlash >= 0) ? path.mid(lastSlash + 1) : path;
+                QString entryName = data.logCategory + '/' + fileMapIt.key() + '/' + fileName;
+                ensureDirectoriesExist(entryName);
+                if (!addFileToZip(path, entryName)) {
+                    qCWarning(logApp) << "Failed to add file to zip:" << path;
+                }
+                emit updatecurrentProcess(++completedTasks);
             }
         }
+        if (m_cancel.load()) break;
 
-        // 复制文件到二级目录
-        if (!m_cancel) {
-            QMapIterator<QString, QStringList> itMap(it.dir2Files);
-            while (itMap.hasNext()) {
-                itMap.next();
-                if (m_cancel)
-                    break;
+        // Commands in category root
+        for (const auto &command : data.commands) {
+            if (m_cancel.load()) break;
+            QString entryName = data.logCategory + '/' + command + ".log";
+            ensureDirectoriesExist(entryName);
+            
+            if (command == "journalctl_system") {
+                addProcessOutputToZip("journalctl", QStringList(), entryName);
+            } else if (command == "journalctl_boot") {
+                addProcessOutputToZip("journalctl", QStringList() << "-b", entryName);
+            } else if (command == "dmesg") {
+                addProcessOutputToZip("dmesg", QStringList(), entryName);
+            } else if (command == "last") {
+                addProcessOutputToZip("last", QStringList(), entryName);
+            } else {
+                // Generic command handling
+                addProcessOutputToZip(command, QStringList(), entryName);
+            }
+            emit updatecurrentProcess(++completedTasks);
+        }
+        if (m_cancel.load()) break;
 
-                if (itMap.value().size() > 0) {
-                    QString tmpSubCategoryPath = QString("%1%2/").arg(tmpCategoryPath).arg(itMap.key());
-                    Utils::mkMutiDir(tmpSubCategoryPath);
-                    for (auto &path : itMap.value()) {
-                        DLDBusHandler::instance(this)->exportLog(tmpSubCategoryPath, path, true);
-                        emit updatecurrentProcess(currentProcess++);
-                        if (m_cancel) {
-                            break;
-                        }
+        // Commands in subdirectories
+        QMapIterator<QString, QStringList> cmdMapIt(data.dir2Cmds);
+        while (cmdMapIt.hasNext()) {
+            if (m_cancel.load()) break;
+            cmdMapIt.next();
+            for (const auto &cmdJson : cmdMapIt.value()) {
+                if (m_cancel.load()) break;
+                
+                // Parse JSON command configuration
+                QJsonDocument doc = QJsonDocument::fromJson(cmdJson.toUtf8());
+                if (doc.isObject()) {
+                    QJsonObject obj = doc.object();
+                    QString logType = obj["logType"].toString();
+                    QString filter = obj["filter"].toString();
+                    
+                    if (logType == "journal" && !filter.isEmpty()) {
+                        QString entryName = data.logCategory + '/' + cmdMapIt.key() + '/' + filter + ".log";
+                        ensureDirectoriesExist(entryName);
+                        addProcessOutputToZip("journalctl", QStringList() << "-u" << filter, entryName);
                     }
+                } else {
+                    // Fallback for malformed JSON
+                    QString entryName = data.logCategory + '/' + cmdMapIt.key() + "/journal.log";
+                    ensureDirectoriesExist(entryName);
+                    addProcessOutputToZip("journalctl", QStringList(), entryName);
                 }
+                emit updatecurrentProcess(++completedTasks);
             }
-        } else
-            break;
-
-        // 导出命令查询内容到二级目录
-        if (!m_cancel) {
-            QMapIterator<QString, QStringList> itMap(it.dir2Cmds);
-            while (itMap.hasNext()) {
-                itMap.next();
-                if (m_cancel)
-                    break;
-
-                if (itMap.value().size() > 0) {
-                    QString tmpSubCategoryPath = QString("%1%2/").arg(tmpCategoryPath).arg(itMap.key());
-                    Utils::mkMutiDir(tmpSubCategoryPath);
-                    for (auto &cmd : itMap.value()) {
-                        DLDBusHandler::instance(this)->exportLog(tmpSubCategoryPath, cmd, false);
-                        emit updatecurrentProcess(currentProcess++);
-                        if (m_cancel) {
-                            break;
-                        }
-                    }
-                }
-            }
-        } else
-            break;
-
-        // 执行获取日志命令
-        if (!m_cancel) {
-            for (auto &command : it.commands) {
-                DLDBusHandler::instance(this)->exportLog(tmpCategoryPath, command, false);
-                emit updatecurrentProcess(currentProcess++);
-                if (m_cancel) {
-                    break;
-                }
-            }
-        } else
-            break;
+        }
     }
 
-    if (!m_cancel) {
-        qCDebug(logApp) << "Packaging exported logs into:" << m_outfile;
-        //打包日志文件
-        Utils::executeCmd("chmod", QStringList() << "-R" << "777" << Utils::getAppDataPath(), tmpPath);
-        Utils::executeCmd("zip", QStringList() << "-r" << "tmp.zip" << "./", tmpPath);
-        Utils::executeCmd("mv", QStringList() << "tmp.zip" << m_outfile, tmpPath);
-        Utils::executeCmd("chmod", QStringList() << "777" << m_outfile, tmpPath);
-        currentProcess += 9;
-        emit updatecurrentProcess(currentProcess);
-    }
+    zipClose(m_zipFile, "Exported by Deepin Log Viewer");
+    m_zipFile = nullptr;
 
-    //删除临时目录
-    dir.removeRecursively();
-    //取消导出删除输出文件
-    if (m_cancel) {
+    if (m_cancel.load()) {
         qCInfo(logApp) << "Export cancelled, removing output file";
         QFile::remove(m_outfile);
+        emit exportFinsh(false);
+    } else {
+        qCDebug(logApp) << "Export finished successfully";
+        emit exportFinsh(true);
     }
-    bool success = !m_cancel && QFileInfo(m_outfile).exists();
-    qCDebug(logApp) << "Export finished with status:" << success;
-    emit exportFinsh(success);
 }

--- a/application/logallexportthread.h
+++ b/application/logallexportthread.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,31 +6,51 @@
 #define LOGALLEXPORTTHREAD_H
 
 #include "structdef.h"
+#include "zip.h"
 
 #include <QObject>
-#include <QRunnable>
+#include <atomic>
 
 class LogAllExportThread : public QObject
-    , public QRunnable
 {
     Q_OBJECT
 public:
     explicit LogAllExportThread(const QStringList &types, const QString &outfile, QObject *parent = nullptr);
-public slots:
-    void slot_cancelExport() { m_cancel = true; }
 
-protected:
-    void run() override;
+public slots:
+    void slot_cancelExport() {
+        m_cancel.store(true);
+    }
+    void run();
+
 signals:
     void updatecurrentProcess(int current);
     void updateTolProcess(int tol);
     void exportFinsh(bool success = true);
 
 private:
+    bool addFileToZip(const QString &filePath, const QString &zipEntryName);
+    bool addProcessOutputToZip(const QString &command, const QStringList &args, const QString &zipEntryName);
+    void ensureDirectoriesExist(const QString &filePath);
+    
+    // Optimized cancel check with reduced atomic load frequency
+    inline bool shouldCancel() const {
+        // Check every 8th call to reduce atomic operations, but always check if cancelled
+        if (++m_cancelCheckCounter % 8 == 0 || m_lastCancelState) {
+            m_lastCancelState = m_cancel.load();
+            return m_lastCancelState;
+        }
+        return m_lastCancelState;
+    }
+
     QStringList m_types;
     QString m_outfile {""};
+    zipFile m_zipFile {nullptr};
 
-    bool m_cancel {false};
+    std::atomic<bool> m_cancel;
+    mutable int m_cancelCheckCounter = 0;  // Reduce atomic load frequency
+    mutable bool m_lastCancelState = false;  // Cache last cancel state
+
 };
 
 #endif // LOGALLEXPORTTHREAD_H


### PR DESCRIPTION
Replace temporary file-based export with direct ZIP streaming using minizip library. This eliminates intermediate file creation and system command dependencies, significantly improving performance and reliability for large log exports.

Log:  Use direct zip streaming for export all logs.
Bug: https://pms.uniontech.com/bug-view-323639.html