### PR TITLE
chore: update gitignore and debian postinst script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,16 @@ CMakeCache.txt
 
 # Auto Claude data directory
 .auto-claude/
+
+# debian
+debian/.debhelper/
+debian/debhelper-build-stamp
+debian/deepin-log-viewer.postrm.debhelper
+debian/deepin-log-viewer.substvars
+debian/deepin-log-viewer/
+debian/files
+debian/liblogviewerplugin-dev.substvars
+debian/liblogviewerplugin-dev/
+debian/liblogviewerplugin.substvars
+debian/liblogviewerplugin/
+debian/tmp/

--- a/debian/deepin-log-viewer.postinst
+++ b/debian/deepin-log-viewer.postinst
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+#DEBHELPER#
+
 # 停止并更新 systemd user timer, 避免由其发起的周期日志导出, 该操作会弹出授权框
 
 #获取已登陆的用户


### PR DESCRIPTION
1. Added Debian build artifacts to gitignore to prevent tracking temporary build files
2. Added #DEBHELPER# placeholder to debian/deepin-log-viewer.postinst script for proper debhelper integration
3. Maintained existing functionality for systemd user timer management

Influence:
1. Verify Debian package builds correctly without including temporary files
2. Test that post-installation script still properly manages systemd user timers
3. Ensure git status remains clean after build operations
4. Confirm debhelper can properly process the postinst script during package builds

chore: 更新 gitignore 文件和 debian postinst 脚本

1. 将 Debian 构建产物添加到 gitignore，避免跟踪临时构建文件
2. 在 debian/deepin-log-viewer.postinst 脚本中添加 #DEBHELPER# 占位符以 支持 debhelper 集成
3. 保持现有的 systemd 用户定时器管理功能

Influence:
1. 验证 Debian 软件包构建正确，不包含临时文件
2. 测试安装后脚本仍能正确管理系统用户定时器
3. 确保构建操作后 git 状态保持干净
4. 确认 debhelper 在软件包构建期间能正确处理 postinst 脚本