### PR TITLE
fix: The shortcut Ctrl+F cannot jump to the search bar.

### DIFF
--- a/application/logcollectormain.cpp
+++ b/application/logcollectormain.cpp
@@ -553,9 +553,9 @@ void LogCollectorMain::initShortCut()
     if (nullptr == m_scFindFont) {
         m_scFindFont = new QShortcut(this);
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-        m_scWndReize->setKey(Qt::CTRL + Qt::Key_F);
+        m_scFindFont->setKey(Qt::CTRL + Qt::Key_F);
 #else
-        m_scWndReize->setKey(QKeyCombination(Qt::CTRL, Qt::Key_F));
+        m_scFindFont->setKey(QKeyCombination(Qt::CTRL, Qt::Key_F));
 #endif
         m_scFindFont->setContext(Qt::ApplicationShortcut);
         m_scFindFont->setAutoRepeat(false);


### PR DESCRIPTION
log: Changed m_scWndReize->setKey to m_scFindFont->setKey to correctly bind Ctrl+F to the search shortcut.

pms: bug-351401