### PR TITLE
fix(ui): fix log list view background style

### DIFF
--- a/application/loglistview.cpp
+++ b/application/loglistview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -168,6 +168,8 @@ void LogListView::initUI()
     this->setMinimumWidth(150);
     this->setEditTriggers(QAbstractItemView::NoEditTriggers);
     this->setItemDelegate(new LogListDelegate(this));
+    this->setBackgroundType(static_cast<DStyledItemDelegate::BackgroundType>(
+        DStyledItemDelegate::RoundedBackground | DStyledItemDelegate::NoNormalState));
     this->setItemSpacing(0);
     this->setViewportMargins(10, 10, 10, 0);
     Dtk::Core::DSysInfo::UosEdition edition = Dtk::Core::DSysInfo::uosEditionType();


### PR DESCRIPTION
Add RoundedBackground and NoNormalState to log list view background.

为日志列表视图添加圆角背景和无正常状态样式。

Log: 修复日志列表视图背景样式
PMS: BUG-316599
Influence: 修复后日志列表视图的背景样式正确显示，提升视觉效果。