### PR TITLE
feat(opslogexport): add apt and uos-ste log export support

### DIFF
--- a/logViewerService/opslogexport.cpp
+++ b/logViewerService/opslogexport.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -229,6 +229,8 @@ void OpsLogExport::run()
     exportOSVersionLogs();
     exportDebVersionLogs();
     exportAdditionalLogs();
+    exportAptLogs();
+    exportUosSteLogs();
 
     // 递归设置目录及文件的权限
     executCmd(("chmod -R 777 " + target_dir).c_str());
@@ -312,7 +314,9 @@ void OpsLogExport::createDirStruct()
         target_dir + "/dde/dde-file-manager",
         target_dir + "/dde/dde-dock",
         target_dir + "/system/pulseaudio",
-        target_dir + "/journal"
+        target_dir + "/journal",
+        target_dir + "/apt",
+        target_dir + "/uos-ste"
     };
 
     // hisi目录仅在源目录存在时创建
@@ -531,4 +535,16 @@ void OpsLogExport::exportAdditionalLogs()
     
     // journal日志：完整导出/var/log/journal目录下的所有内容
     copy_file_or_dir("/var/log/journal", target_dir + "/journal/");
+}
+
+void OpsLogExport::exportAptLogs()
+{
+    // apt日志：完整导出/var/log/apt目录下的所有内容
+    copy_file_or_dir("/var/log/apt", target_dir);
+}
+
+void OpsLogExport::exportUosSteLogs()
+{
+    // uos-ste日志：完整导出/var/log/uos-ste目录下的所有内容
+    copy_file_or_dir("/var/log/uos-ste", target_dir);
 }

--- a/logViewerService/opslogexport.h
+++ b/logViewerService/opslogexport.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -31,6 +31,8 @@ private:
     void exportOSVersionLogs();
     void exportDebVersionLogs();
     void exportAdditionalLogs();
+    void exportAptLogs();
+    void exportUosSteLogs();
 };
 
 #endif


### PR DESCRIPTION
Add exportAptLogs() and exportUosSteLogs() to export apt package manager logs and uos-ste logs to the ops log directory.

新增apt和uos-ste日志导出功能，将相关日志文件导出到运维日志目录。

Log: 新增apt和uos-ste日志导出
Task: https://pms.uniontech.com/task-view-389455.html
Influence: 运维日志导出时将额外收集/var/log/apt和/var/log/uos-ste目录下的日志。