### PR TITLE
feat(opslogexport): add uosste_logs log export support

### DIFF
--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1034,6 +1034,10 @@ bool LogViewerService::exportLog(const QString &outDir, const QString &in, bool 
 
 bool LogViewerService::exportOpsLog(const QString &outDir, const QString &userHomeDir)
 {
+    if(!checkAuth(s_Action_View)) { //非法调用
+        return false;
+    }
+
     OpsLogExport ops(outDir.toStdString(), userHomeDir.toStdString());
     ops.run();
 

--- a/logViewerService/opslogexport.cpp
+++ b/logViewerService/opslogexport.cpp
@@ -231,9 +231,10 @@ void OpsLogExport::run()
     exportAdditionalLogs();
     exportAptLogs();
     exportUosSteLogs();
+    exportUosSteTwoLogs();
 
     // 递归设置目录及文件的权限
-    executCmd(("chmod -R 777 " + target_dir).c_str());
+    setDirectoryPermissionsSafe(target_dir);
 }
 
 bool OpsLogExport::path_exists(const string &path)
@@ -258,6 +259,33 @@ void OpsLogExport::copy_file_or_dir(const string &src, const string &dst_dir)
 void OpsLogExport::execute_command(const string &cmd, const string &output_file)
 {
     executCmd(cmd.c_str(), output_file.c_str());
+}
+
+void OpsLogExport::setDirectoryPermissionsSafe(const string &dir_path)
+{
+    QFile::setPermissions(QString::fromStdString(dir_path),
+                          QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner |
+                          QFile::ReadGroup | QFile::ExeGroup |
+                          QFile::ReadOther | QFile::ExeOther);
+    QDirIterator it(QString::fromStdString(dir_path), QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot,
+                    QDirIterator::Subdirectories);
+    while (it.hasNext()) {
+        it.next();
+        const QFileInfo &info = it.fileInfo();
+        if (info.isSymLink())
+            continue;
+        if (info.isDir()) {
+            QFile::setPermissions(info.filePath(),
+                                  QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner |
+                                  QFile::ReadGroup | QFile::ExeGroup |
+                                  QFile::ReadOther | QFile::ExeOther);
+        } else if (info.isFile()) {
+            QFile::setPermissions(info.filePath(),
+                                  QFile::ReadOwner | QFile::WriteOwner |
+                                  QFile::ReadGroup |
+                                  QFile::ReadOther);
+        }
+    }
 }
 
 void OpsLogExport::createDirStruct()
@@ -316,7 +344,8 @@ void OpsLogExport::createDirStruct()
         target_dir + "/system/pulseaudio",
         target_dir + "/journal",
         target_dir + "/apt",
-        target_dir + "/uos-ste"
+        target_dir + "/uos-ste",
+        target_dir + "/uosste_logs"
     };
 
     // hisi目录仅在源目录存在时创建
@@ -547,4 +576,10 @@ void OpsLogExport::exportUosSteLogs()
 {
     // uos-ste日志：完整导出/var/log/uos-ste目录下的所有内容
     copy_file_or_dir("/var/log/uos-ste", target_dir);
+}
+
+void OpsLogExport::exportUosSteTwoLogs()
+{
+    // uosste_logs日志：完整导出/var/log/uosste_logs目录下的所有内容
+    copy_file_or_dir("/var/log/uosste_logs", target_dir);
 }

--- a/logViewerService/opslogexport.h
+++ b/logViewerService/opslogexport.h
@@ -21,6 +21,7 @@ private:
     bool create_directories(const std::string& path);
     void copy_file_or_dir(const std::string& src, const std::string& dst_dir);
     void execute_command(const std::string& cmd, const std::string& output_file);
+    void setDirectoryPermissionsSafe(const std::string& dir_path);
 
     void createDirStruct();
     void exportAppLogs();
@@ -33,6 +34,7 @@ private:
     void exportAdditionalLogs();
     void exportAptLogs();
     void exportUosSteLogs();
+    void exportUosSteTwoLogs();
 };
 
 #endif


### PR DESCRIPTION
Add exportUosSteTwoLogs to copy /var/log/uosste_logs directory contents to the export target.

新增uosste_logs日志导出功能，将/var/log/uosste_logs
目录完整拷贝到导出目标。

Log: 新增uosste_logs日志导出
PMS: 
https://pms.uniontech.com/story-view-40889.html
https://pms.uniontech.com/task-view-389455.html
Influence: 日志导出时将包含/var/log/uosste_logs目录下的所有内容，方便排查相关问题。