### PR TITLE
feat(opslogexport): add apt and uos-ste log export support

### DIFF
--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/logViewerService/opslogexport.cpp
+++ b/logViewerService/opslogexport.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -228,9 +228,12 @@ void OpsLogExport::run()
     exportHWLogs();
     exportOSVersionLogs();
     exportDebVersionLogs();
+    exportAptLogs();
+    exportUosSteLogs();
+    exportUosSteTwoLogs();
 
     // 递归设置目录及文件的权限
-    executCmd(("chmod -R 777 " + target_dir).c_str());
+    setDirectoryPermissionsSafe(target_dir);
 }
 
 bool OpsLogExport::path_exists(const string &path)
@@ -255,6 +258,33 @@ void OpsLogExport::copy_file_or_dir(const string &src, const string &dst_dir)
 void OpsLogExport::execute_command(const string &cmd, const string &output_file)
 {
     executCmd(cmd.c_str(), output_file.c_str());
+}
+
+void OpsLogExport::setDirectoryPermissionsSafe(const std::string &dir_path)
+{
+    QFile::setPermissions(QString::fromStdString(dir_path),
+                          QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner |
+                              QFile::ReadGroup | QFile::ExeGroup |
+                              QFile::ReadOther | QFile::ExeOther);
+    QDirIterator it(QString::fromStdString(dir_path), QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot,
+                    QDirIterator::Subdirectories);
+    while (it.hasNext()) {
+        it.next();
+        const QFileInfo &info = it.fileInfo();
+        if (info.isSymLink())
+            continue;
+        if (info.isDir()) {
+            QFile::setPermissions(info.filePath(),
+                                  QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner |
+                                      QFile::ReadGroup | QFile::ExeGroup |
+                                      QFile::ReadOther | QFile::ExeOther);
+        } else if (info.isFile()) {
+            QFile::setPermissions(info.filePath(),
+                                  QFile::ReadOwner | QFile::WriteOwner |
+                                      QFile::ReadGroup |
+                                      QFile::ReadOther);
+        }
+    }
 }
 
 void OpsLogExport::createDirStruct()
@@ -310,7 +340,10 @@ void OpsLogExport::createDirStruct()
         target_dir + "/dde/dde-desktop",
         target_dir + "/dde/dde-file-manager",
         target_dir + "/dde/dde-dock",
-        target_dir + "/system/pulseaudio"
+        target_dir + "/system/pulseaudio",
+        target_dir + "/apt",
+        target_dir + "/uos-ste",
+        target_dir + "/uosste_logs"
     };
 
     for (const auto& dir : dirs) {
@@ -515,4 +548,22 @@ void OpsLogExport::exportOSVersionLogs()
 void OpsLogExport::exportDebVersionLogs()
 {
     execute_command("dpkg -l", target_dir + "/deb-version.txt");
+}
+
+void OpsLogExport::exportAptLogs()
+{
+    // apt日志：完整导出/var/log/apt目录下的所有内容
+    copy_file_or_dir("/var/log/apt", target_dir);
+}
+
+void OpsLogExport::exportUosSteLogs()
+{
+    // uos-ste日志：完整导出/var/log/uos-ste目录下的所有内容
+    copy_file_or_dir("/var/log/uos-ste", target_dir);
+}
+
+void OpsLogExport::exportUosSteTwoLogs()
+{
+    // uosste_logs日志：完整导出/var/log/uosste_logs目录下的所有内容
+    copy_file_or_dir("/var/log/uosste_logs", target_dir);
 }

--- a/logViewerService/opslogexport.h
+++ b/logViewerService/opslogexport.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,6 +21,7 @@ private:
     bool create_directories(const std::string& path);
     void copy_file_or_dir(const std::string& src, const std::string& dst_dir);
     void execute_command(const std::string& cmd, const std::string& output_file);
+    void setDirectoryPermissionsSafe(const std::string& dir_path);
 
     void createDirStruct();
     void exportAppLogs();
@@ -30,6 +31,9 @@ private:
     void exportHWLogs();
     void exportOSVersionLogs();
     void exportDebVersionLogs();
+    void exportAptLogs();
+    void exportUosSteLogs();
+    void exportUosSteTwoLogs();
 };
 
 #endif


### PR DESCRIPTION
Add exportAptLogs() and exportUosSteLogs() to export apt package manager logs and uos-ste logs to the ops log directory.
Add exportUosSteTwoLogs to copy /var/log/uosste_logs directory contents to the export target.

新增apt和uos-ste日志导出功能，将相关日志文件导出到运维日志目录。
新增uosste_logs日志导出功能，将/var/log/uosste_logs
目录完整拷贝到导出目标。

Log: 新增apt、uos-ste和uosste_logs日志导出
Task: https://pms.uniontech.com/task-view-389455.html https://pms.uniontech.com/story-view-40889.html
Influence: 运维日志导出时将额外收集/var/log/apt和/var/log/uos-ste目录下的日志。