### PR TITLE
feat(application): add coredump collection for file manager processes…

### DIFF
--- a/application/logauththread.cpp
+++ b/application/logauththread.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1551,6 +1551,11 @@ void LogAuthThread::handleCoredump()
             #endif
         } else {
             coredumpMsg.storagePath = QString("coredump file is missing");
+        }
+
+        if ((exePath.contains("dde-file-manager-server") || exePath.contains("dde-file-manager-daemon"))
+            && coredumpMsg.stackInfo.contains("delete")) {
+            continue;
         }
 
         coredumpList.append(coredumpMsg);


### PR DESCRIPTION
… with delete in stack

- Add condition to  coredump collection when process contains "delete" in stack info
- Apply filtering specifically to dde-file-manager-server and dde-file-manager-daemon processes
- Prevent unnecessary coredump collection for expected delete-related crashes

Log: feat(application): skip coredump collection for file manager processes with delete in stack
Task: https://pms.uniontech.com/task-view-387813.html