### PR TITLE
fix(build): use DTK library variables instead of CMake targets for CI…

### DIFF
--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -115,9 +115,9 @@ set(LINK_LIBS
     Qt${QT_DESIRED_VERSION}::Network
     Qt${QT_DESIRED_VERSION}::Widgets
     Qt${QT_DESIRED_VERSION}::Concurrent
-    Dtk${DTK_VERSION_MAJOR}::Widget
-    Dtk${DTK_VERSION_MAJOR}::Core
-    Dtk${DTK_VERSION_MAJOR}::Gui
+    ${DtkWidget_LIBRARIES}
+    ${DtkCore_LIBRARIES}
+    ${DtkGui_LIBRARIES}
     PolkitQt${QT_DESIRED_VERSION}-1::Agent
 )
 

--- a/application/logviewheaderview.cpp
+++ b/application/logviewheaderview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -255,9 +255,9 @@ int LogViewHeaderView::sectionSizeHint(int logicalIndex) const
 
 void LogViewHeaderView::updateSizeMode()
 {
-    qCDebug(logApp) << "Updating size mode, compact:" << DGuiApplicationHelper::isCompactMode();
     int nRowHeight = ROW_HEIGHT;
 #ifdef DTKWIDGET_CLASS_DSizeMode
+    qCDebug(logApp) << "Updating size mode, compact:" << DGuiApplicationHelper::isCompactMode();
     if (DGuiApplicationHelper::isCompactMode())
         nRowHeight = ROW_HEIGHT_COMPACT;
     else

--- a/liblogviewerplugin/CMakeLists.txt
+++ b/liblogviewerplugin/CMakeLists.txt
@@ -63,9 +63,9 @@ set(LINK_LIBS
     Qt${QT_DESIRED_VERSION}::Gui
     Qt${QT_DESIRED_VERSION}::Concurrent
     Qt${QT_DESIRED_VERSION}::Widgets
-    Dtk${DTK_VERSION_MAJOR}::Widget
-    Dtk${DTK_VERSION_MAJOR}::Core
-    Dtk${DTK_VERSION_MAJOR}::Gui
+    ${DtkWidget_LIBRARIES}
+    ${DtkCore_LIBRARIES}
+    ${DtkGui_LIBRARIES}
     PolkitQt${QT_DESIRED_VERSION}-1::Agent
 )
 

--- a/logViewerService/CMakeLists.txt
+++ b/logViewerService/CMakeLists.txt
@@ -44,8 +44,8 @@ set(LINK_LIBS
     Qt${QT_DESIRED_VERSION}::Core
     Qt${QT_DESIRED_VERSION}::DBus
     Qt${QT_DESIRED_VERSION}::Widgets
-    Dtk${DTK_VERSION_MAJOR}::Core
-    Dtk${DTK_VERSION_MAJOR}::Gui
+    ${DtkCore_LIBRARIES}
+    ${DtkGui_LIBRARIES}
     PolkitQt${QT_DESIRED_VERSION}-1::Agent
 )
 


### PR DESCRIPTION
… compat

Replace Dtk::Widget/Core/Gui targets with ${DtkXxx_LIBRARIES} variables to avoid dependency on DtkConfig.cmake unified entry, fixing CI build failure on eagle/1050 where Dtk_DIR cache points to wrong path.

将DTK链接方式从CMake target改为库变量，避免依赖DtkConfig.cmake
统一入口，修复CI环境中DTK_DIR缓存路径错误导致的构建失败。

Log: 修复CI构建DTK链接失败问题
Influence: 修复CI构建，不影响本地开发环境。