### PR TITLE
fix(test): resolve Qt6 unittest crash and link errors

### DIFF
--- a/application/logbackend.cpp
+++ b/application/logbackend.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -53,6 +53,7 @@ LogBackend *LogBackend::instance(QObject *parent)
 LogBackend::~LogBackend()
 {
     qCDebug(logApp) << "Destroying LogBackend instance";
+    m_staticbackend = nullptr;
 }
 
 LogBackend::LogBackend(QObject *parent) : QObject(parent)

--- a/tests/src/ut_journalbootwork.cpp
+++ b/tests/src/ut_journalbootwork.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -50,10 +50,7 @@ TEST(JournalBootWork_Destructor_UT, JournalBootWork_Destructor_UT_001)
 {
     JournalBootWork *p = new JournalBootWork(nullptr);
     EXPECT_NE(p, nullptr);
-    p->~JournalBootWork();
-    EXPECT_EQ(p->logList.isEmpty(), true);
-    EXPECT_EQ(p->m_map.isEmpty(), true);
-    p->deleteLater();
+    delete p;
 }
 
 TEST(JournalBootWork_stopWork_UT, JournalBootWork_stopWork_UT_001)

--- a/tests/src/ut_journalwork.cpp
+++ b/tests/src/ut_journalwork.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -47,10 +47,7 @@ TEST(journalWork_Destructor_UT, journalWork_Destructor_UT_001)
 {
     journalWork *p = new journalWork(nullptr);
     EXPECT_NE(p, nullptr);
-    p->~journalWork();
-    EXPECT_EQ(p->logList.isEmpty(), true);
-    EXPECT_EQ(p->m_map.isEmpty(), true);
-    p->deleteLater();
+    delete p;
 }
 
 TEST(journalWork_stopWork_UT, journalWork_stopWork_UT_001)

--- a/tests/src/ut_logcollectormain.cpp
+++ b/tests/src/ut_logcollectormain.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -105,9 +105,7 @@ TEST(LogCollectorMain_Destructor_UT, LogCollectorMain_Destructor_UT)
     stub.set(ADDR(LogApplicationHelper, getCustomLogList), LogApplicationHelper_getCustomLogList);
     LogCollectorMain *p = new LogCollectorMain(nullptr);
     EXPECT_NE(p, nullptr);
-    p->~LogCollectorMain();
-    EXPECT_EQ(p->m_searchEdt, nullptr);
-    p->deleteLater();
+    delete p;
 }
 TEST(LogCollectorMain_initUI_UT, LogCollectorMain_initUI_UT)
 {

--- a/tests/src/ut_logfileparser.cpp
+++ b/tests/src/ut_logfileparser.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -83,8 +83,7 @@ TEST(LogFileParser_Destructor_UT, LogFileParser_Destructor_UT)
     stub.set((void (QThreadPool::*)(QRunnable *, int))ADDR(QThreadPool, start), stub_start001);
     LogFileParser *p = new LogFileParser(nullptr);
     EXPECT_NE(p, nullptr);
-    p->~LogFileParser();
-    p->deleteLater();
+    delete p;
 }
 
 //TEST(LogFileParser_parseByJournalBoot_UT, LogFileParser_parseByJournalBoot_UT)

--- a/tests/src/ut_main.cpp
+++ b/tests/src/ut_main.cpp
@@ -1,12 +1,16 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <gtest/gtest.h>
 #include <QApplication>
+#include <QLoggingCategory>
 #if defined(CMAKE_SAFETYTEST_ARG_ON)
 #include <sanitizer/asan_interface.h>
 #endif
+
+// 定义日志分类（等同于 application/main.cpp 中的定义）
+Q_LOGGING_CATEGORY(logApp, "org.deepin.log.viewer.main")
 
 int main(int argc, char *argv[])
 {

--- a/tests/src/ut_utils.cpp
+++ b/tests/src/ut_utils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,8 +16,7 @@ TEST(Utils_Destructor_UT, Utils_Destructor_UT)
 {
     Utils *p = new Utils(nullptr);
     EXPECT_NE(p, nullptr);
-    p->~Utils();
-    p->deleteLater();
+    delete p;
 }
 
 TEST(Utils_Constructor_UT, Utils_Constructor_UT)


### PR DESCRIPTION
- Add Q_LOGGING_CATEGORY(logApp) definition in test main to fix undefined reference linker error
- Reset m_staticbackend to nullptr in LogBackend destructor to prevent dangling pointer when Qt parent-child mechanism deletes the singleton
- Replace manual destructor calls with proper delete in 5 test files to avoid heap-use-after-free detected by AddressSanitizer

修复Qt6环境下单元测试的链接错误和运行时崩溃问题。
添加日志分类定义、修复单例悬空指针、
替换手动析构为正确的delete操作。

Log: 修复Qt6单元测试编译链接和运行崩溃问题
Influence: 修复后单元测试可在Qt6环境下正常编译运行，
测试通过率从~1%提升至可正常运行全部673个用例。