### PR TITLE
fix(security): replace system() with posix_spawnp() to prevent comman…

### DIFF
--- a/3rdparty/DocxFactory/src/ConverterPrinter/OdfConverterUtil.cpp
+++ b/3rdparty/DocxFactory/src/ConverterPrinter/OdfConverterUtil.cpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "DocxFactory/ConverterPrinter/OdfConverterUtil.h"
 #include "DocxFactory/ConverterPrinter/GradeGroup.h"
@@ -11,6 +14,12 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <spawn.h>
+#include <fcntl.h>
+
+extern char **environ;
 
 #endif
 
@@ -18,22 +27,6 @@
 
 using namespace DocxFactory;
 using namespace std;
-
-
-
-#if defined( _WIN32 ) || defined( _WIN64 )
-
-	#define ODF_CONVERTER_CMD( p_exec, p_importFile, p_exportFile ) \
-		string( "(\"" ) + p_exec + "\" /I \"" + p_importFile + "\" /O \"" + p_exportFile + "\" /F 1> nul 2> nul)"
-
-#else
-
-	#define ODF_CONVERTER_CMD( p_exec, p_importFile, p_exportFile ) \
-		string( "\"" ) + p_exec + "\" /I \"" + p_importFile + "\" /O \"" + p_exportFile + "\" /F 1> /dev/null 2> /dev/null"
-
-#endif
-
-
 
 OdfConverterUtil::OdfConverterUtil() : ConverterPrinterUtil()
 {
@@ -93,16 +86,46 @@ void OdfConverterUtil::saveAs( const string& p_importFile, const string& p_expor
 
 	else
 	{
-		string	l_cmd		= ODF_CONVERTER_CMD( m_exec, p_importFile, p_exportFile );
-		int		l_exitCode	= system( l_cmd.c_str() );
+        // Use posix_spawn instead of fork+exec to avoid issues
+        // with fork() in a multithreaded process.
+        pid_t l_pid = 0;
+        posix_spawn_file_actions_t l_actions;
+
+        posix_spawn_file_actions_init( &l_actions );
+
+        // Redirect stdout and stderr to /dev/null (same as the
+        // original system() command did with "1> /dev/null 2> /dev/null")
+        int l_devNull = open( "/dev/null", O_RDWR );
+        posix_spawn_file_actions_adddup2( &l_actions, l_devNull, STDOUT_FILENO );
+        posix_spawn_file_actions_adddup2( &l_actions, l_devNull, STDERR_FILENO );
+        posix_spawn_file_actions_addclose( &l_actions, l_devNull );
+
+        const char* l_argv[] = {
+            m_exec.c_str(),
+            "/I", p_importFile.c_str(),
+            "/O", p_exportFile.c_str(),
+            "/F", nullptr
+        };
+
+        int l_spawnErr = posix_spawnp(
+                    &l_pid, m_exec.c_str(), &l_actions, nullptr,
+                    (char* const*)l_argv, environ );
+
+        posix_spawn_file_actions_destroy( &l_actions );
+        close( l_devNull );
+
+        if ( l_spawnErr != 0 )
+            throw UtilFailedException( m_exec, __FILE__, __LINE__ );
+
+        int l_status = 0;
+        waitpid( l_pid, &l_status, 0 );
+        int l_exitCode = WEXITSTATUS( l_status );
 
 		if ( l_exitCode != 0 )
 			throw UtilFailedException( m_exec, __FILE__, __LINE__ );
 
-		#ifdef __unix__
-			if ( chmod( p_exportFile.c_str(), S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH ) != 0 )
-				throw UtilFailedException( "chmod", __FILE__, __LINE__ );
-		#endif
+        if ( chmod( p_exportFile.c_str(), S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH ) != 0 )
+            throw UtilFailedException( "chmod", __FILE__, __LINE__ );
 	}
 } // saveAs
 


### PR DESCRIPTION
…d injection

The OdfConverterUtil::saveAs() function built a shell command string via the ODF_CONVERTER_CMD macro and passed it to system(). File paths containing shell metacharacters (e.g. ", ;, $()) could be exploited to execute arbitrary commands.

Replace system() with posix_spawnp() which passes arguments as an array directly to the target executable without shell interpretation, eliminating the injection vector. Use posix_spawn_file_actions_t to redirect stdout and stderr to /dev/null, preserving the original suppression behavior.

Additionally, posix_spawn avoids the fork()-in-multithreaded-process hazards since export operations run on QThreadPool worker threads that may hold QMutex locks.

Remove the now-unused ODF_CONVERTER_CMD macro and the unreachable _WIN32 code path, as deepin-log-viewer is a Linux-only application.

3rdparty/DocxFactory/src/ConverterPrinter/OdfConverterUtil.cpp

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-364711.html