### PR TITLE
fix(desktop): add trailing semicolon to Categories field

### DIFF
--- a/application/assets/deepin-log-viewer.desktop
+++ b/application/assets/deepin-log-viewer.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Categories=Utility
+Categories=Utility;
 Exec=deepin-log-viewer %f
 GenericName=Log Viewer
 Icon=deepin-log-viewer


### PR DESCRIPTION
Add missing semicolon to Categories field in .desktop file per freedesktop.org Desktop Entry specification.

Log: 修复桌面入口文件Categories字段格式不符合规范的问题
PMS: BUG-366913
Influence: 使桌面入口文件符合freedesktop.org规范，通过desktop-file-validate验证。

## Summary by Sourcery

Bug Fixes:
- Correct the Categories field format in the deepin-log-viewer .desktop file to satisfy desktop-file-validate checks.