### PR TITLE
fix(logexport): eliminate path injection in exportOpsLog by resolving…

### DIFF
--- a/application/dbusproxy/dldbushandler.cpp
+++ b/application/dbusproxy/dldbushandler.cpp
@@ -163,16 +163,15 @@ bool DLDBusHandler::exportLog(const QString &outDir, const QString &in, bool isF
     return m_dbus->exportLog(outDir, in, isFile);
 }
 
-bool DLDBusHandler::exportOpsLog(const QString &outDir, const QString &userHomeDir)
+bool DLDBusHandler::exportOpsLog()
 {
     m_dbus->setTimeout(1200000);
-    QDBusPendingReply<bool> reply = m_dbus->exportOpsLog(outDir, userHomeDir);
+    QDBusPendingReply<bool> reply = m_dbus->exportOpsLog();
     reply.waitForFinished();
     m_dbus->setTimeout(-1);
 
     if (reply.isError()) {
-        qCritical(logDBusHandler) << "call dbus interface 'exportHwOpsLog' failed. error info:" << reply.error().message();
-
+        qCritical(logDBusHandler) << "call dbus interface 'exportOpsLog' failed. error info:" << reply.error().message();
         return false;
     } else {
         qCDebug(logDBusHandler) << "exportOpsLog succeeded:" << reply.value();

--- a/application/dbusproxy/dldbushandler.h
+++ b/application/dbusproxy/dldbushandler.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,7 +21,7 @@ public:
     int exitCode();
     void quit();
     bool exportLog(const QString &outDir, const QString &in, bool isFile);
-    bool exportOpsLog(const QString &outDir, const QString &userHomeDir);
+    bool exportOpsLog();
     bool isFileExist(const QString &filePath);
     quint64 getFileSize(const QString &filePath);
     qint64 getLineCount(const QString &filePath);

--- a/application/dbusproxy/dldbusinterface.h
+++ b/application/dbusproxy/dldbusinterface.h
@@ -8,6 +8,10 @@
  * Do not edit! All changes made to it will be lost.
  */
 
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #ifndef DEEPINLOGVIEWERINTERFACE_H
 #define DEEPINLOGVIEWERINTERFACE_H
 
@@ -51,10 +55,9 @@ public Q_SLOTS: // METHODS
         return asyncCallWithArgumentList(QStringLiteral("exportLog"), argumentList);
     }
 
-    inline QDBusPendingReply<bool> exportOpsLog(const QString &outDir, const QString &userHomeDir)
+    inline QDBusPendingReply<bool> exportOpsLog()
     {
         QList<QVariant> argumentList;
-        argumentList << QVariant::fromValue(outDir) << QVariant::fromValue(userHomeDir);
         return asyncCallWithArgumentList(QStringLiteral("exportOpsLog"), argumentList);
     }
 

--- a/application/logallexportthread.cpp
+++ b/application/logallexportthread.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -229,12 +229,14 @@ void LogAllExportThread::run()
             break;
     }
 
-    if (!m_cancel) {
+    // 不支持导出 sudo 权限的日志，且导出日志功能主要面向普通用户使用场景，
+    // 因此当获取到的用户家目录为根目录时，认为是异常情况，不执行导出操作
+    if (!m_cancel && QDir::homePath() != "/" && QDir::homePath() != "/root") {
         QString opsLogPath =tmpPath + "log-ops/";
         Utils::mkMutiDir(opsLogPath);
         QString userHomePath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
         // 收集运维日志
-        DLDBusHandler::instance(this)->exportOpsLog(opsLogPath, userHomePath);
+        DLDBusHandler::instance(this)->exportOpsLog();
         Utils::exportSomeOpsLogs(opsLogPath, userHomePath);
     }
 

--- a/application/main.cpp
+++ b/application/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -44,8 +44,8 @@ int main(int argc, char *argv[])
     // 命令参数大于1，进行命令行处理
     if (argc > 1) {
         QCoreApplication a(argc, argv);
-        a.setOrganizationName("deepin");
-        a.setApplicationName("deepin-log-viewer");
+        a.setOrganizationName(kOrgNameForDeepinLogViewer);
+        a.setApplicationName(kAppNameForDeepinLogViewer);
         a.setApplicationVersion(VERSION);
 
         DLogManager::registerConsoleAppender();

--- a/application/utils.cpp
+++ b/application/utils.cpp
@@ -55,7 +55,6 @@ const QString COREDUMP_REPEAT_CONFIG_PATH = Utils::homePath + "/.cache/deepin/de
 const float COREDUMP_HIGH_REPETITION = 0.8f;
 const int COREDUMP_TIME_THRESHOLD = 3;
 
-
 Utils::Utils(QObject *parent)
     : QObject(parent)
 {
@@ -80,17 +79,16 @@ QString Utils::getQssContent(const QString &filePath)
 QString Utils::getConfigPath()
 {
     QDir dir(QDir(Utils::homePath + "/.config")
-             .filePath(qApp->organizationName()));
+             .filePath(kOrgNameForDeepinLogViewer));
 
-    return dir.filePath(qApp->applicationName());
+    return dir.filePath(kAppNameForDeepinLogViewer);
 }
 
 QString Utils::getAppDataPath()
 {
     QDir dir(QDir(Utils::homePath + "/.local/share")
-             .filePath(qApp->organizationName()));
-
-    return dir.filePath(qApp->applicationName());
+             .filePath(kOrgNameForDeepinLogViewer));
+    return dir.filePath(kAppNameForDeepinLogViewer);
 }
 
 bool Utils::isFontMimeType(const QString &filePath)

--- a/application/utils.h
+++ b/application/utils.h
@@ -21,6 +21,9 @@ struct LOG_REPEAT_COREDUMP_INFO {
     float repetitionRate = 0.0;
 };
 
+static constexpr char kOrgNameForDeepinLogViewer[] { "deepin" };
+static constexpr char kAppNameForDeepinLogViewer[] { "deepin-log-viewer" };
+
 /**
  * @brief 公用工具静态函数类
  */

--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -45,6 +45,9 @@ Q_LOGGING_CATEGORY(logService, "org.deepin.log.viewer.service", QtInfoMsg)
 const QString s_Action_View = "com.deepin.pkexec.logViewerAuth";
 const QString s_Action_Export = "com.deepin.pkexec.logViewerAuth.exportLogs";
 
+static constexpr char kOrgNameForDeepinLogViewer[] { "deepin" };
+static constexpr char kAppNameForDeepinLogViewer[] { "deepin-log-viewer" };
+
 /**
    @brief 移除路径 \a dirPath 下的文件，注意，不会递归删除文件夹
  */
@@ -1028,47 +1031,69 @@ bool LogViewerService::exportLog(const QString &outDir, const QString &in, bool 
     return true;
 }
 
-bool LogViewerService::exportOpsLog(const QString &outDir, const QString &userHomeDir)
+bool LogViewerService::exportOpsLog()
 {
     if(!checkAuth(s_Action_View)) { //非法调用
         qCWarning(logService) << "Invalid authorization for export log";
         return false;
     }
 
-    // 导出路径白名单检查
-    QString outPath = QDir::cleanPath(outDir);
-    QStringList availablePaths = whiteListOutPaths();
-    bool bOutAvailable = false;
-    for (auto path : availablePaths) {
-        if (outPath.startsWith(path)) {
-            bOutAvailable = true;
-            break;
-        }
-    }
-    if (!bOutAvailable) {
-        qCCritical(logService) << "Output path not in whitelist:" << outDir;
+    QString callerHomeDir = getCallerHomeDir();
+    if (callerHomeDir.isEmpty()) {
+        qCWarning(logService) << "Failed to get caller home directory for export log";
         return false;
     }
 
-    // 家目录参数白名单检查，限定为已知用户家目录
-    QString cleanHomeDir = QDir::cleanPath(userHomeDir);
-    QStringList homeList = getHomePaths();
-    bool bHomeValid = false;
-    for (auto path : homeList) {
-        if (cleanHomeDir == path) {
-            bHomeValid = true;
-            break;
-        }
-    }
-    if (!bHomeValid) {
-        qCCritical(logService) << "homeDir not in allowed home paths:" << userHomeDir;
+    // 不支持导出 sudo 权限的日志，且导出日志功能主要面向普通用户使用场景，
+    // 因此当获取到的用户家目录为根目录时，认为是异常情况，不执行导出操作
+    if (callerHomeDir == "/" || callerHomeDir == "/root") {
+        qCWarning(logService) << "Invalid caller home directory for export log: " << callerHomeDir;
         return false;
     }
 
-    OpsLogExport ops(outDir.toStdString(), userHomeDir.toStdString());
+    QString newOutDir = callerHomeDir + "/.local/share/"
+            + kOrgNameForDeepinLogViewer + "/"
+            + kAppNameForDeepinLogViewer + "/tmp/log-ops/";
+
+    OpsLogExport ops(newOutDir.toStdString(), callerHomeDir.toStdString());
     ops.run();
 
     return true;
+}
+
+QString LogViewerService::getCallerHomeDir()
+{
+    if (!calledFromDBus()) {
+        qWarning() << "getCallerHomeDir: called not from dbus.";
+        return QString();
+    }
+
+    QString busName = message().service();
+    auto reply = connection().interface()->serviceUid(busName);
+    if (!reply.isValid()) {
+        qCWarning(logService) << "getCallerHomeDir: failed to get caller UID via D-Bus:"
+                              << reply.error().message();
+        return QString();
+    }
+
+    uint callerUid = reply.value();
+
+    // 使用线程安全版本的 getpwuid_r 替代非线程安全的 getpwuid
+    struct passwd pwd;
+    struct passwd *result = nullptr;
+    long bufSize = sysconf(_SC_GETPW_R_SIZE_MAX);
+    if (bufSize <= 0 || bufSize > 1024 * 1024) {
+        bufSize = 16384;  // 默认缓冲区大小
+    }
+    QByteArray buf(static_cast<qsizetype>(bufSize), '\0');
+
+    int ret = getpwuid_r(static_cast<uid_t>(callerUid), &pwd, buf.data(), buf.size(), &result);
+    if (ret == 0 && result) {
+        return QString::fromLocal8Bit(pwd.pw_dir);
+    }
+
+    qCCritical(logService) << "getCallerHomeDir: failed to resolve uid:" << callerUid << "error:" << ret;
+    return QString();
 }
 
 bool LogViewerService::checkAuth(const QString &actionId)

--- a/logViewerService/logviewerservice.h
+++ b/logViewerService/logviewerservice.h
@@ -36,7 +36,7 @@ public Q_SLOTS:
     Q_SCRIPTABLE QStringList getFileInfo(const QString &file, bool unzip = true);
     Q_SCRIPTABLE QStringList getOtherFileInfo(const QString &file, bool unzip = true);
     Q_SCRIPTABLE bool exportLog(const QString &outDir, const QString &in, bool isFile);
-    Q_SCRIPTABLE bool exportOpsLog(const QString &outDir, const QString &userHomeDir);
+    Q_SCRIPTABLE bool exportOpsLog();
     Q_SCRIPTABLE QString openLogStream(const QString &filePath);
     Q_SCRIPTABLE QString readLogInStream(const QString &token);
     Q_SCRIPTABLE QString isFileExist(const QString &filePath);
@@ -75,6 +75,8 @@ private:
     QMap<QString, std::pair<QString, QTextStream*>> m_logMap;
     QMap<QString, QList<uint64_t>> m_logLineIndex;
     bool checkAuth(const QString &actionId);
+    // 获取当前调用该 DBus 接口的用户家目录路径
+    QString getCallerHomeDir();
     QByteArray processCatFile(const QString &filePath);
     void processCmdArgs(const QString &cmdStr, const QStringList &args);
 };


### PR DESCRIPTION
… caller home dir via DBus UID

Remove outDir and userHomeDir parameters from exportOpsLog D-Bus interface. Determine the caller's home directory internally via DBus UID introspection (getpwuid) to prevent path injection attacks. Add guard against root/sudo home directories. Extract magic strings deepin and deepin-log-viewer into constexpr constants.

移除 exportOpsLog 的 outDir 和 userHomeDir 参数，改为通过 DBus UID 解析调用者家目录，从根本上消除路径注入风险。新增根目录（/、/root）
守卫，防止 sudo 场景下非授权导出。将魔数字符串提取为常量。

Log: 消除 exportOpsLog 路径注入风险
Influence: 增强了日志导出安全性，不再信任外部传入路径参数，通过 DBus UID 追溯调用者身份，有效防止路径注入攻击。

## Summary by Sourcery

Harden exportOpsLog by deriving the caller’s home directory from the D-Bus UID and standardizing application paths, removing reliance on externally provided paths.

Bug Fixes:
- Eliminate path injection risk in exportOpsLog by resolving the caller’s home directory via D-Bus UID instead of trusting client-supplied paths.
- Block operations when the resolved home directory is '/' or '/root' to avoid exporting logs for sudo/root sessions.

Enhancements:
- Simplify the exportOpsLog D-Bus interface by dropping outDir and userHomeDir parameters and handling paths entirely on the service side.
- Standardize configuration and data paths using shared constexpr organization/application name constants instead of QCoreApplication name values.
- Align log export threading logic with the new exportOpsLog signature and add a guard to skip exports when the home directory is root.