### PR TITLE
fix(logexport): eliminate path injection in exportOpsLog by resolving…

### DIFF
--- a/application/dbusproxy/dldbushandler.cpp
+++ b/application/dbusproxy/dldbushandler.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -172,22 +172,18 @@ QStringList DLDBusHandler::getOtherFileInfo(const QString &flag, bool unzip)
     return filePathList;
 }
 
-bool DLDBusHandler::exportOpsLog(const QString &outDir, const QString &userHomeDir)
+QString DLDBusHandler::exportOpsLog()
 {
-    qCDebug(logApp) << "DLDBusHandler::exportOpsLog called:" << outDir << userHomeDir;
-
     m_dbus->setTimeout(1200000);
-    QDBusPendingReply<bool> reply = m_dbus->exportOpsLog(outDir, userHomeDir);
+    QDBusPendingReply<QString> reply = m_dbus->exportOpsLog();
     reply.waitForFinished();
     m_dbus->setTimeout(-1);
 
     if (reply.isError()) {
         qCWarning(logApp) << "call dbus iterface 'exportOpsLog()' failed. error info:" << reply.error().message();
-        return false;
-    } else {
-        qCDebug(logApp) << "exportOpsLog succeeded:" << reply.value();
-        return reply.value();
+        return QString();
     }
+    return reply.value();
 }
 
 bool DLDBusHandler::exportLog(const QString &outDir, const QString &in, bool isFile)

--- a/application/dbusproxy/dldbushandler.h
+++ b/application/dbusproxy/dldbushandler.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,7 +21,7 @@ public:
     int exitCode();
     void quit();
     bool exportLog(const QString &outDir, const QString &in, bool isFile);
-    bool exportOpsLog(const QString &outDir, const QString &userHomeDir);
+    QString exportOpsLog();
     bool isFileExist(const QString &filePath);
     quint64 getFileSize(const QString &filePath);
     qint64 getLineCount(const QString &filePath);

--- a/application/dbusproxy/dldbusinterface.h
+++ b/application/dbusproxy/dldbusinterface.h
@@ -8,6 +8,10 @@
  * Do not edit! All changes made to it will be lost.
  */
 
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #ifndef DEEPINLOGVIEWERINTERFACE_H
 #define DEEPINLOGVIEWERINTERFACE_H
 
@@ -147,10 +151,9 @@ public Q_SLOTS: // METHODS
         return asyncCallWithArgumentList(QStringLiteral("whiteListOutPaths"), argumentList);
     }
 
-    inline QDBusPendingReply<bool> exportOpsLog(const QString &outDir, const QString &userHomeDir)
+    inline QDBusPendingReply<QString> exportOpsLog()
     {
         QList<QVariant> argumentList;
-        argumentList << QVariant::fromValue(outDir) << QVariant::fromValue(userHomeDir);
         return asyncCallWithArgumentList(QStringLiteral("exportOpsLog"), argumentList);
     }
 Q_SIGNALS: // SIGNALS

--- a/application/logallexportthread.cpp
+++ b/application/logallexportthread.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,7 +16,6 @@
 #include <QDateTime>
 #include <QSet>
 #include <QStandardPaths>
-#include <QTemporaryDir>
 
 Q_DECLARE_LOGGING_CATEGORY(logApp)
 
@@ -468,14 +467,13 @@ void LogAllExportThread::run()
     }
 
     // --- Export additional ops logs ---
-    if (!m_cancel.load()) {
-        // Create temporary directory for ops logs
+    // 不支持导出 sudo 权限的日志，且导出日志功能主要面向普通用户使用场景，
+    // 因此当获取到的用户家目录为根目录时，认为是异常情况，不执行导出操作
+    if (!m_cancel.load() && QDir::homePath() != "/" && QDir::homePath() != "/root") {
+        // Create a fixed temporary directory for ops logs
         QString userHomePath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
-        QTemporaryDir tempDir(QDir::tempPath() + "/XXXXXX");
-
-        if (tempDir.isValid()) {
-            QString opsLogPath = tempDir.path();
-            DLDBusHandler::instance(this)->exportOpsLog(opsLogPath, userHomePath);
+        QString opsLogPath = DLDBusHandler::instance(this)->exportOpsLog();
+        if (!opsLogPath.isEmpty()) {
             completedTasks += 5;
             emit updatecurrentProcess(completedTasks);
             Utils::exportSomeOpsLogs(opsLogPath, userHomePath);

--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -287,6 +287,41 @@ qint64 LogViewerService::readFileAndReturnIndex(const QString &filePath, qint64 
     return lineIndexes.at(startLine); // 返回给定起始行的索引
 }
 
+QString LogViewerService::getCallerHomeDir()
+{
+    if (!calledFromDBus()) {
+        qWarning() << "getCallerHomeDir: called not from dbus.";
+        return QString();
+    }
+
+    QString busName = message().service();
+    auto reply = connection().interface()->serviceUid(busName);
+    if (!reply.isValid()) {
+        qCWarning(logService) << "getCallerHomeDir: failed to get caller UID via D-Bus:"
+                              << reply.error().message();
+        return QString();
+    }
+
+    uint callerUid = reply.value();
+
+    // 使用线程安全版本的 getpwuid_r 替代非线程安全的 getpwuid
+    struct passwd pwd;
+    struct passwd *result = nullptr;
+    long bufSize = sysconf(_SC_GETPW_R_SIZE_MAX);
+    if (bufSize <= 0 || bufSize > 1024 * 1024) {
+        bufSize = 16384;  // 默认缓冲区大小
+    }
+    QByteArray buf(static_cast<qsizetype>(bufSize), '\0');
+
+    int ret = getpwuid_r(static_cast<uid_t>(callerUid), &pwd, buf.data(), buf.size(), &result);
+    if (ret == 0 && result) {
+        return QString::fromLocal8Bit(pwd.pw_dir);
+    }
+
+    qCCritical(logService) << "getCallerHomeDir: failed to resolve uid:" << callerUid << "error:" << ret;
+    return QString();
+}
+
 /**
    @brief Polkit action authorization check.
         Use com.deepin.pkexec.logViewerAuth.policy config file.
@@ -1191,46 +1226,35 @@ bool LogViewerService::checkAuth(const QString &actionId)
     return  bAuthVaild;
 }
 
-bool LogViewerService::exportOpsLog(const QString &outDir, const QString &homeDir)
+QString LogViewerService::exportOpsLog()
 {
-    qCDebug(logService) << "exportOpsLog for outDir:" << outDir << "and homeDir:" << homeDir;
     if(!checkAuth(s_Action_View)) {
         qCWarning(logService) << "Invalid authorization for export log";
-        return false;
+        return QString();
     }
 
-    // 导出路径白名单检查
-    QString outPath = QDir::cleanPath(outDir);
-    QStringList availablePaths = whiteListOutPaths();
-    bool bOutAvailable = false;
-    for (auto path : availablePaths) {
-        if (outPath.startsWith(path)) {
-            bOutAvailable = true;
-            break;
-        }
-    }
-    if (!bOutAvailable) {
-        qCCritical(logService) << "Output path not in whitelist:" << outDir;
-        return false;
+    QString callerHomeDir = getCallerHomeDir();
+    if (callerHomeDir.isEmpty()) {
+        qCWarning(logService) << "Failed to get caller home directory for export log";
+        return QString();
     }
 
-    // 家目录参数白名单检查，限定为已知用户家目录
-    QString cleanHomeDir = QDir::cleanPath(homeDir);
-    QStringList homeList = getHomePaths();
-    bool bHomeValid = false;
-    for (auto path : homeList) {
-        if (cleanHomeDir == path) {
-            bHomeValid = true;
-            break;
-        }
-    }
-    if (!bHomeValid) {
-        qCCritical(logService) << "homeDir not in allowed home paths:" << homeDir;
-        return false;
+    // 不支持导出 sudo 权限的日志，且导出日志功能主要面向普通用户使用场景，
+    // 因此当获取到的用户家目录为根目录时，认为是异常情况，不执行导出操作
+    if (callerHomeDir == "/" || callerHomeDir == "/root") {
+        qCWarning(logService) << "Invalid caller home directory for export log: " << callerHomeDir;
+        return QString();
     }
 
-    OpsLogExport ops(outDir.toStdString(), homeDir.toStdString());
+    QByteArray tmpTemplate = "/tmp/deepin-log-viewer-ops-logs.XXXXXX";
+    if (!mkdtemp(tmpTemplate.data())) {
+        qCCritical(logService) << "Failed to create secure temp directory";
+        return QString();
+    }
+    QString newOutDir = tmpTemplate;
+
+    OpsLogExport ops(newOutDir.toStdString(), callerHomeDir.toStdString());
     ops.run();
 
-    return true;
+    return newOutDir;
 }

--- a/logViewerService/logviewerservice.h
+++ b/logViewerService/logviewerservice.h
@@ -45,7 +45,7 @@ public Q_SLOTS:
     Q_SCRIPTABLE QString executeCmd(const QString &cmd);
     Q_SCRIPTABLE QStringList whiteListOutPaths();
 
-    Q_SCRIPTABLE bool exportOpsLog(const QString &outDir, const QString &homeDir);
+    Q_SCRIPTABLE QString exportOpsLog();
 
 public:
     // 获取用户家目录
@@ -64,6 +64,9 @@ private:
     qint64 findLineStartOffsetWithCaching(const QString &filePath, qint64 targetLine);
 
     qint64 readFileAndReturnIndex(const QString &filePath, qint64 startLine, QList<uint64_t>& lineIndexes, bool reverseOrder);
+
+    // 获取当前调用该 DBus 接口的用户家目录路径
+    QString getCallerHomeDir();
 
 private:
     bool checkAuthorization(const QString &actionId);


### PR DESCRIPTION
… caller home dir via DBus UID

Remove outDir and userHomeDir parameters from exportOpsLog D-Bus interface. Determine the caller's home directory internally via DBus UID introspection (getpwuid) to prevent path injection attacks. Add guard against root/sudo home directories. Extract magic strings deepin and deepin-log-viewer into constexpr constants.

移除 exportOpsLog 的 outDir 和 userHomeDir 参数，改为通过 DBus UID 解析调用者家目录，从根本上消除路径注入风险。新增根目录（/、/root）
守卫，防止 sudo 场景下非授权导出。将魔数字符串提取为常量。

Log: 消除 exportOpsLog 路径注入风险
Influence: 增强了日志导出安全性，不再信任外部传入路径参数，通过 DBus UID 追溯调用者身份， 有效防止路径注入攻击。

## Summary by Sourcery

Resolve the ops log export destination internally and derive the caller’s home directory via D-Bus UID to eliminate path injection risks and block sudo/root-based exports.

Bug Fixes:
- Remove reliance on caller-supplied output and home directory paths for exportOpsLog, resolving a potential path injection vulnerability.
- Guard against exports when the resolved caller home directory is '/' or '/root' to prevent unauthorized sudo/root log exports.

Enhancements:
- Centralize resolution of the D-Bus caller’s home directory using a thread-safe UID lookup helper in the log viewer service.
- Standardize ops log export to a fixed temporary directory shared between the service and client, and simplify the D-Bus exportOpsLog interface by removing path parameters.
- Update file copyright headers and add SPDX metadata in the D-Bus interface header.