### PR TITLE
fix: resolve multiple polkit auth dialogs and mutex crashes in app lo…

### DIFF
--- a/application/dbusproxy/dldbushandler.cpp
+++ b/application/dbusproxy/dldbushandler.cpp
@@ -143,6 +143,11 @@ void DLDBusHandler::quit()
     m_dbus->quit();
 }
 
+bool DLDBusHandler::isGetFileInfoError() const
+{
+    return m_bGetFileInfoError;
+}
+
 QStringList DLDBusHandler::getFileInfo(const QString &flag, bool unzip)
 {
     qCDebug(logApp) << "DLDBusHandler::getFileInfo called with flag:" << flag << "unzip:" << unzip;
@@ -150,9 +155,11 @@ QStringList DLDBusHandler::getFileInfo(const QString &flag, bool unzip)
     reply.waitForFinished();
     if (reply.isError()) {
         qCWarning(logApp) << "call dbus iterface 'getFileInfo()' failed. error info:" << reply.error().message();
+        m_bGetFileInfoError = true;
     } else {
         qCDebug(logApp) << "getFileInfo succeeded, file count:" << reply.value().size();
         filePath = reply.value();
+        m_bGetFileInfoError = false;
     }
     return filePath;
 }

--- a/application/dbusproxy/dldbushandler.h
+++ b/application/dbusproxy/dldbushandler.h
@@ -17,6 +17,7 @@ public:
     QString readLog(const QString &filePath);
     QStringList readLogLinesInRange(const QString &filePath, qint64 startLine = 0, qint64 lineCount = 500, bool bReverse = true);
     QStringList getFileInfo(const QString &flag, bool unzip = true);
+    bool isGetFileInfoError() const;
     QStringList getOtherFileInfo(const QString &flag, bool unzip = true);
     int exitCode();
     void quit();
@@ -41,6 +42,7 @@ private:
     static DLDBusHandler *m_statichandeler;
     DeepinLogviewerInterface *m_dbus;
     QStringList filePath;
+    bool m_bGetFileInfoError = false;
 
     QTemporaryDir m_tempDir;
 };

--- a/application/filtercontent.cpp
+++ b/application/filtercontent.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -468,7 +468,11 @@ void FilterContent::setSelection(FILTER_CONFIG iConifg)
         cbx_dnf_lv->setCurrentIndex(iConifg.dnfCbx);
     }
     m_btnGroup->button(iConifg.dateBtn)->setChecked(true); //add by Airy for bug 19660:period button default setting
-    Q_EMIT m_btnGroup->button(iConifg.dateBtn)->click();
+    // 对于应用日志(APP_TREE_DATA)，应用下拉框变更(slot_cbxAppIdxChanged)已经触发了generateAppFile数据加载，
+    // 并且已携带了正确的dateBtn参数，此处不应再emit click()否则会导致重复加载（引发多次授权弹框）
+    if (m_currentType != APP_TREE_DATA) {
+        Q_EMIT m_btnGroup->button(iConifg.dateBtn)->click();
+    }
 }
 
 /**

--- a/application/logapplicationparsethread.cpp
+++ b/application/logapplicationparsethread.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -149,9 +149,15 @@ bool LogApplicationParseThread::parseByFile(const APP_FILTERS &app_filter)
         emit appFinished(m_threadCount);
     } else {
         QStringList filePath = DLDBusHandler::instance(this)->getFileInfo(m_AppFiler.path);
+        // 如果getFileInfo的dbus调用失败(如用户取消授权)，直接返回false以中止后续子模块处理
+        if (DLDBusHandler::instance(this)->isGetFileInfoError()) {
+            qCWarning(logApp) << "D-Bus getFileInfo failed (authorization canceled) for submodule:"
+                            << app_filter.submodule << ", aborting remaining submodules";
+            emit appFinished(m_threadCount);
+            return false;
+        }
         for (int i = 0; i < filePath.count(); i++) {
             if (!m_canRun) {
-                mutex.unlock();
                 return false;
             }
             //按行解析
@@ -159,7 +165,6 @@ bool LogApplicationParseThread::parseByFile(const APP_FILTERS &app_filter)
             // dbus鉴权失败，不再继续解析
             if (outByte.endsWith("is not allowed to configrate firewall. checkAuthorization failed.")) {
                 qCWarning(logApp) << "D-Bus authorization failed for file:" << filePath[i];
-                mutex.unlock();
                 emit appFinished(m_threadCount);
                 return false;
             }
@@ -170,7 +175,6 @@ bool LogApplicationParseThread::parseByFile(const APP_FILTERS &app_filter)
 
             for (int j = strList.size() - 1; j >= 0; --j) {
                 if (!m_canRun) {
-                    mutex.unlock();
                     return false;
                 }
                 LOG_MSG_APPLICATOIN msg;
@@ -218,7 +222,6 @@ bool LogApplicationParseThread::parseByFile(const APP_FILTERS &app_filter)
                 }
             }
             if (!m_canRun) {
-                mutex.unlock();
                 return false;
             }
         }
@@ -234,7 +237,6 @@ bool LogApplicationParseThread::parseByJournal(const APP_FILTERS &app_filter)
 
     if ((!m_canRun)) {
         qCWarning(logApp) << "Thread stopped before journal parsing";
-        mutex.unlock();
         return false;
     }
 
@@ -243,13 +245,11 @@ bool LogApplicationParseThread::parseByJournal(const APP_FILTERS &app_filter)
     sd_journal *j ;
     if ((!m_canRun)) {
         qCWarning(logApp) << "Thread stopped before journal opening";
-        mutex.unlock();
         return false;
     }
     //打开日志文件
     r = sd_journal_open(&j, SD_JOURNAL_LOCAL_ONLY);
     if ((!m_canRun)) {
-        mutex.unlock();
         sd_journal_close(j);
         return false;
     }
@@ -261,7 +261,6 @@ bool LogApplicationParseThread::parseByJournal(const APP_FILTERS &app_filter)
     //从尾部开始读，这样出来数据是倒叙，符合需求
     sd_journal_seek_tail(j);
     if ((!m_canRun)) {
-        mutex.unlock();
         sd_journal_close(j);
         return false;
     }
@@ -302,7 +301,6 @@ bool LogApplicationParseThread::parseByJournal(const APP_FILTERS &app_filter)
     }
 
     if ((!m_canRun)) {
-        mutex.unlock();
         sd_journal_close(j);
         return false;
     }
@@ -322,7 +320,6 @@ bool LogApplicationParseThread::parseByJournal(const APP_FILTERS &app_filter)
     //调用宏开始迭代
     SD_JOURNAL_FOREACH_BACKWARDS(j) {
         if ((!m_canRun)) {
-            mutex.unlock();
             sd_journal_close(j);
             return false;
         }


### PR DESCRIPTION
…g parsing

- Track D-Bus authorization failure state in DLDBusHandler: set m_bGetFileInfoError on QDBusReply error, reset on success.
- Abort remaining application submodules when getFileInfo() D-Bus call fails (e.g. user cancels polkit dialog), preventing cascading authorization prompts.
- Skip duplicate emit click() in FilterContent::setSelection() for APP_TREE_DATA, as the combo box change signal already triggers generateAppFile with correct parameters. This eliminates the redundant data loading path that caused repeated polkit dialogs.
- Remove 9 superfluous mutex.unlock() calls across parseByFile() and parseByJournal() that had no corresponding mutex.lock(), which caused "QMutex::unlock: mutex lock failure: Invalid argument" crashes.

Log: 修复应用日志多次弹出授权框及 mutex 解锁崩溃问题
Bug: https://pms.uniontech.com/bug-view-366823.html