### PR TITLE
chore: add OPT_ENABLE_BUILD_UT option to control unit test building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ endif ()
 project(deepin_log_viewer)
 option(DMAN_RELEAE OFF "Install dman resources to system or not")
 
+option(OPT_ENABLE_BUILD_UT "Build unit tests" ON)
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 # 引入翻译生成
 include(translation-generate)
@@ -29,8 +31,10 @@ add_subdirectory(logViewerTruncate)
 
 add_subdirectory(logViewerService)
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    add_subdirectory(tests)
+if (OPT_ENABLE_BUILD_UT)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_subdirectory(tests)
+    endif()
 endif()
 
 add_subdirectory(liblogviewerplugin)


### PR DESCRIPTION
Introduce a new CMake option `OPT_ENABLE_BUILD_UT` (default ON) to conditionally build unit tests. The tests subdirectory is now gated by this option first, then by the Debug build type check, making it possible to disable unit test builds independently of the build type.