### PR TITLE
fix: handle D-Bus auth failure and mutex UB in log parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,17 @@ endif ()
 #这里项目名称绝对不能和编译出的target名称一样
 project(deepin_log_viewer)
 option(DMAN_RELEAE OFF "Install dman resources to system or not")
+option(OPT_ENABLE_BUILD_UT "Build unit tests" ON)
 add_subdirectory(application)
 add_subdirectory(logViewerAuth)
 add_subdirectory(logViewerTruncate)
 
 add_subdirectory(logViewerService)
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    add_subdirectory(tests)
+if (OPT_ENABLE_BUILD_UT)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_subdirectory(tests)
+    endif()
 endif()
 
 add_subdirectory(liblogviewerplugin)

--- a/application/dbusproxy/dldbushandler.cpp
+++ b/application/dbusproxy/dldbushandler.cpp
@@ -138,10 +138,17 @@ QStringList DLDBusHandler::getFileInfo(const QString &flag, bool unzip)
     reply.waitForFinished();
     if (reply.isError()) {
         qCWarning(logDBusHandler) << "call dbus iterface 'getFileInfo()' failed. error info:" << reply.error().message();
+        m_getFileInfoError = true;
     } else {
         filePath = reply.value();
+        m_getFileInfoError = false;
     }
     return filePath;
+}
+
+bool DLDBusHandler::isGetFileInfoError() const
+{
+    return m_getFileInfoError;
 }
 
 QStringList DLDBusHandler::getOtherFileInfo(const QString &flag, bool unzip)

--- a/application/dbusproxy/dldbushandler.h
+++ b/application/dbusproxy/dldbushandler.h
@@ -17,6 +17,7 @@ public:
     QString readLog(const QString &filePath);
     QStringList readLogLinesInRange(const QString &filePath, qint64 startLine = 0, qint64 lineCount = 500, bool bReverse = true);
     QStringList getFileInfo(const QString &flag, bool unzip = true);
+    bool isGetFileInfoError() const;
     QStringList getOtherFileInfo(const QString &flag, bool unzip = true);
     int exitCode();
     void quit();
@@ -41,6 +42,7 @@ private:
     static DLDBusHandler *m_statichandeler;
     DeepinLogviewerInterface *m_dbus;
     QStringList filePath;
+    bool m_getFileInfoError = false;
 
     QTemporaryDir m_tempDir;
 };

--- a/application/filtercontent.cpp
+++ b/application/filtercontent.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -431,7 +431,11 @@ void FilterContent::setSelection(FILTER_CONFIG iConifg)
         cbx_dnf_lv->setCurrentIndex(iConifg.dnfCbx);
     }
     m_btnGroup->button(iConifg.dateBtn)->setChecked(true); //add by Airy for bug 19660:period button default setting
-    Q_EMIT m_btnGroup->button(iConifg.dateBtn)->click();
+    // 对于应用日志(APP_TREE_DATA)，应用下拉框变更(slot_cbxAppIdxChanged)已经触发了generateAppFile数据加载，
+    // 并且已携带了正确的dateBtn参数，此处不应再emit click()否则会导致重复加载（引发多次授权弹框）
+    if (m_currentType != APP_TREE_DATA) {
+        Q_EMIT m_btnGroup->button(iConifg.dateBtn)->click();
+    }
 }
 
 /**

--- a/application/logapplicationparsethread.cpp
+++ b/application/logapplicationparsethread.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -125,16 +125,21 @@ bool LogApplicationParseThread::parseByFile(const APP_FILTERS &app_filter)
         emit appFinished(m_threadCount);
     } else {
         QStringList filePath = DLDBusHandler::instance(this)->getFileInfo(m_AppFiler.path);
+        // 如果getFileInfo的dbus调用失败(如用户取消授权)，直接返回false以中止后续子模块处理
+        if (DLDBusHandler::instance(this)->isGetFileInfoError()) {
+            qCWarning(logApp) << "D-Bus getFileInfo failed (authorization canceled) for submodule:"
+                              << app_filter.submodule << ", aborting remaining submodules";
+            emit appFinished(m_threadCount);
+            return false;
+        }
         for (int i = 0; i < filePath.count(); i++) {
             if (!m_canRun) {
-                mutex.unlock();
                 return false;
             }
             //按行解析
             QByteArray outByte = DLDBusHandler::instance(this)->readLog(filePath[i]).toUtf8();
             // dbus鉴权失败，不再继续解析
             if (outByte.endsWith("is not allowed to configrate firewall. checkAuthorization failed.")) {
-                mutex.unlock();
                 emit appFinished(m_threadCount);
                 return false;
             }
@@ -145,7 +150,6 @@ bool LogApplicationParseThread::parseByFile(const APP_FILTERS &app_filter)
 
             for (int j = strList.size() - 1; j >= 0; --j) {
                 if (!m_canRun) {
-                    mutex.unlock();
                     return false;
                 }
                 LOG_MSG_APPLICATOIN msg;
@@ -193,7 +197,6 @@ bool LogApplicationParseThread::parseByFile(const APP_FILTERS &app_filter)
                 }
             }
             if (!m_canRun) {
-                mutex.unlock();
                 return false;
             }
         }
@@ -207,7 +210,6 @@ bool LogApplicationParseThread::parseByJournal(const APP_FILTERS &app_filter)
     m_AppFiler = app_filter;
 
     if ((!m_canRun)) {
-        mutex.unlock();
         return false;
     }
 
@@ -215,13 +217,11 @@ bool LogApplicationParseThread::parseByJournal(const APP_FILTERS &app_filter)
 
     sd_journal *j ;
     if ((!m_canRun)) {
-        mutex.unlock();
         return false;
     }
     //打开日志文件
     r = sd_journal_open(&j, SD_JOURNAL_LOCAL_ONLY);
     if ((!m_canRun)) {
-        mutex.unlock();
         sd_journal_close(j);
         return false;
     }
@@ -233,7 +233,6 @@ bool LogApplicationParseThread::parseByJournal(const APP_FILTERS &app_filter)
     //从尾部开始读，这样出来数据是倒叙，符合需求
     sd_journal_seek_tail(j);
     if ((!m_canRun)) {
-        mutex.unlock();
         sd_journal_close(j);
         return false;
     }
@@ -274,7 +273,6 @@ bool LogApplicationParseThread::parseByJournal(const APP_FILTERS &app_filter)
     }
 
     if ((!m_canRun)) {
-        mutex.unlock();
         sd_journal_close(j);
         return false;
     }
@@ -294,7 +292,6 @@ bool LogApplicationParseThread::parseByJournal(const APP_FILTERS &app_filter)
     //调用宏开始迭代
     SD_JOURNAL_FOREACH_BACKWARDS(j) {
         if ((!m_canRun)) {
-            mutex.unlock();
             sd_journal_close(j);
             return false;
         }


### PR DESCRIPTION
Add getFileInfo error tracking to abort remaining submodules on D-Bus authorization failure. Prevent duplicate click events for APP_TREE_DATA to avoid repeated authorization dialogs. Remove redundant mutex.unlock() calls from early-return paths where the mutex is not held (UB fix).

增加getFileInfo的D-Bus调用失败检测，在中止授权后停止后续子模块处理；
修复应用日志类型下重复加载导致多次授权弹框的问题；
移除未持锁状态下的mutex.unlock()调用，消除未定义行为风险。

Log: 修复D-Bus鉴权失败相关问题和mutex未定义行为
PMS: BUG-366125
Influence: 修复因D-Bus鉴权失败导致的多重授权弹框问题，
修正mutex未持锁时调用unlock()的未定义行为风险。