### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/application/assets/deepin-log-viewer.desktop
+++ b/application/assets/deepin-log-viewer.desktop
@@ -80,6 +80,6 @@ Name[ug]=خاتىرە كۆرگۈچ Deepin
 Name[uk]=Переглядач журналів Deepin
 Name[lo]=ເຄື່ອງເບິ່ງບັນທຶກ
 Name[zh_CN]=日志收集工具
-Name[zh_HK]=Deepin 日誌查看器
-Name[zh_TW]=Deepin 日誌收集工具
+Name[zh_HK]=日誌查看器
+Name[zh_TW]=日誌收集工具
 


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Bug Fixes:
- Correct Chinese desktop entry translations by removing unnecessary "深度"/"deepin" prefixes from Name and Comment fields for zh_CN, zh_HK, and zh_TW.