### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/application/assets/deepin-log-viewer.desktop
+++ b/application/assets/deepin-log-viewer.desktop
@@ -8,6 +8,7 @@ StartupNotify=false
 TryExec=deepin-log-viewer
 Type=Application
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

Enhancements:
- Declare deepin-log-viewer as a singleton app in the desktop file using the X-Deepin-Singleton flag.