### PR TITLE
chore: Update version to 6.5.34

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-log-viewer (6.5.34) unstable; urgency=medium
+
+  * chore: Update version to 6.5.34
+  * chore(ci): update actions/checkout to v7 and enable unsafe PR checkout
+  * fix: add X-Deepin-Singleton flag to desktop file
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 30 Jul 2026 15:14:35 +0800
+
 deepin-log-viewer (6.5.33) unstable; urgency=medium
 
   * chore: Update version to 6.5.33


### PR DESCRIPTION
- update version to 6.5.34

log: update version to 6.5.34

## Summary by Sourcery

Build:
- Bump Debian changelog version entry to 6.5.34.