### PR TITLE
fix(security): add polkit auth check to getFileSize D-Bus method

### DIFF
--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -802,6 +802,10 @@ QString LogViewerService::isFileExist(const QString &filePath)
 quint64 LogViewerService::getFileSize(const QString &filePath)
 {
     qCDebug(logService) << "Getting file size for:" << filePath;
+    if (!checkAuth(s_Action_View)) {
+        return 0;
+    }
+
     QFileInfo fi(filePath);
     if (fi.exists())
         return static_cast<quint64>(fi.size());


### PR DESCRIPTION
## 根因分析

`LogViewerService::getFileSize` D-Bus 方法以 root 权限运行，但缺少 polkit 认证检查，任意本地用户可通过系统总线获取任意 root 可读文件的精确大小信息，造成信息泄露。

**关键证据**：
- `logViewerService/logviewerservice.cpp:802` — `getFileSize` 方法入口无 `checkAuth(s_Action_View)` 调用
- 同类 10 个公共 D-Bus 槽方法中，唯独 `getFileSize` 缺少认证检查
- 紧邻的 `isFileExist`（:790）和 `getLineCount`（:607）均正确执行了 `checkAuth`

## 修复方案

在 `getFileSize` 方法入口添加 `checkAuth(s_Action_View)` 认证检查，认证失败时返回 `0`，与同类方法 `isFileExist`、`getLineCount` 的模式一致。

## 改动安全评估

低风险。仅添加 early return 认证检查，不改变函数签名，不影响已授权调用者的行为。所有引用点为声明或 D-Bus 适配器转发层，无直接业务调用者会因修复而行为变化。

## Summary by Sourcery

Bug Fixes:
- Guard the getFileSize D-Bus method with a polkit-based view authorization check, returning 0 when the caller is not authorized.