### PR TITLE
fix: add AT-SPI accessible interfaces and element names for log viewer

### DIFF
--- a/application/accessible.h
+++ b/application/accessible.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -39,6 +39,22 @@
 #include <QObject>
 #include <QMetaEnum>
 #include <QWidget>
+
+// 自定义控件头文件，用于 AT-SPI accessible 接口
+#include "loglistview.h"
+#include "logtreeview.h"
+#include "logcombox.h"
+#include "logperiodbutton.h"
+#include "lognormalbutton.h"
+#include "logiconbutton.h"
+#include "logspinnerwidget.h"
+#include "logdetailinfowidget.h"
+#include "logdetailedit.h"
+#include "exportprogressdlg.h"
+#include "displaycontent.h"
+#include "filtercontent.h"
+#include "logcollectormain.h"
+#include "logtableview.h"
 
 inline constexpr char kSeparator[] { "_" };
 
@@ -258,10 +274,66 @@ inline QString getAccessibleName(QWidget *w, QAccessible::Role r, QString fallba
 /********************** 添加accessible ***********************/
 SET_FORM_ACCESSIBLE(QWidget,m_w->objectName())
 
+// LogListView - 日志类型选择列表
+SET_FORM_ACCESSIBLE(LogListView,m_w->objectName())
+
+// LogTreeView - 主日志数据表格
+SET_FORM_ACCESSIBLE(LogTreeView,m_w->objectName())
+
+// LogCombox - 自定义下拉框
+SET_FORM_ACCESSIBLE(LogCombox,m_w->objectName())
+
+// LogPeriodButton - 时间周期按钮（继承DPushButton）
+SET_BUTTON_ACCESSIBLE(LogPeriodButton,m_w->objectName())
+
+// LogNormalButton - 普通按钮（继承DPushButton）
+SET_BUTTON_ACCESSIBLE(LogNormalButton,m_w->objectName())
+
+// LogIconButton - 图标按钮（继承QPushButton）
+SET_BUTTON_ACCESSIBLE(LogIconButton,m_w->objectName())
+
+// LogSpinnerWidget - 加载转圈控件
+SET_FORM_ACCESSIBLE(LogSpinnerWidget,m_w->objectName())
+
+// logDetailInfoWidget - 详情信息面板
+SET_FORM_ACCESSIBLE(logDetailInfoWidget,m_w->objectName())
+
+// logDetailEdit - 详情文本浏览器
+SET_FORM_ACCESSIBLE(logDetailEdit,m_w->objectName())
+
+// ExportProgressDlg - 导出进度对话框
+SET_FORM_ACCESSIBLE(ExportProgressDlg,m_w->objectName())
+
+// FilterContent - 筛选内容面板（DFrame）
+SET_FORM_ACCESSIBLE(FilterContent,m_w->objectName())
+
+// DisplayContent - 显示内容面板（DWidget）
+SET_FORM_ACCESSIBLE(DisplayContent,m_w->objectName())
+
+// LogCollectorMain - 主窗口（DMainWindow）
+SET_FORM_ACCESSIBLE(LogCollectorMain,m_w->objectName())
+
+// LogTableView - 表格视图
+SET_FORM_ACCESSIBLE(LogTableView,m_w->objectName())
+
 QAccessibleInterface *accessibleFactory(const QString &classname, QObject *object)
 {
     QAccessibleInterface *interface = nullptr;
     USE_ACCESSIBLE(classname, QWidget);
+    USE_ACCESSIBLE(classname, LogListView);
+    USE_ACCESSIBLE(classname, LogTreeView);
+    USE_ACCESSIBLE(classname, LogCombox);
+    USE_ACCESSIBLE(classname, LogPeriodButton);
+    USE_ACCESSIBLE(classname, LogNormalButton);
+    USE_ACCESSIBLE(classname, LogIconButton);
+    USE_ACCESSIBLE(classname, LogSpinnerWidget);
+    USE_ACCESSIBLE(classname, logDetailInfoWidget);
+    USE_ACCESSIBLE(classname, logDetailEdit);
+    USE_ACCESSIBLE(classname, ExportProgressDlg);
+    USE_ACCESSIBLE(classname, FilterContent);
+    USE_ACCESSIBLE(classname, DisplayContent);
+    USE_ACCESSIBLE(classname, LogCollectorMain);
+    USE_ACCESSIBLE(classname, LogTableView);
 
     return interface;
 }

--- a/application/displaycontent.cpp
+++ b/application/displaycontent.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -111,6 +111,7 @@ void DisplayContent::initUI()
 
     //noResultLabel
     noResultLabel = new DLabel(this);
+    noResultLabel->setAccessibleName("noResultLabel");
     DPalette pa = DPaletteHelper::instance()->palette(noResultLabel);
     pa.setBrush(DPalette::WindowText, pa.color(DPalette::TextTips));
     noResultLabel->setPalette(pa);
@@ -120,6 +121,7 @@ void DisplayContent::initUI()
 
     //notAuditLabel
     notAuditLabel = new DLabel(this);
+    notAuditLabel->setAccessibleName("notAuditLabel");
     DPalette auditPa = DPaletteHelper::instance()->palette(notAuditLabel);
     auditPa.setBrush(DPalette::WindowText, auditPa.color(DPalette::TextTips));
     noResultLabel->setPalette(auditPa);
@@ -128,12 +130,14 @@ void DisplayContent::initUI()
     notAuditLabel->setAlignment(Qt::AlignCenter);
 
     noCoredumpctlLabel = new DLabel(this);
+    noCoredumpctlLabel->setAccessibleName("noCoredumpctlLabel");
     noCoredumpctlLabel->setPalette(pa);
     noCoredumpctlLabel->setText(DApplication::translate("Waring", "Unable to obtain crash information, please install systemd-coredump."));
     DFontSizeManager::instance()->bind(noCoredumpctlLabel, DFontSizeManager::T4);
     noCoredumpctlLabel->setAlignment(Qt::AlignCenter);
 
     noPermissionLabel = new DLabel(this);
+    noPermissionLabel->setAccessibleName("noPermissionLabel");
     noPermissionLabel->setPalette(pa);
     noPermissionLabel->setText(DApplication::translate("Warning", "You do not have permission to view it"));
     DFontSizeManager::instance()->bind(noPermissionLabel, DFontSizeManager::T4);

--- a/application/filtercontent.cpp
+++ b/application/filtercontent.cpp
@@ -74,25 +74,32 @@ void FilterContent::initUI()
     // set period info
     hLayout_period = new QHBoxLayout;
     periodLabel = new DLabel(DApplication::translate("Label", "Period:"), this);
+    periodLabel->setAccessibleName("periodLabel");
     periodLabel->setAlignment(Qt::AlignRight | Qt::AlignCenter);
     m_btnGroup = new QButtonGroup(this);
     //初始化时间筛选按钮部分布局
     m_allBtn = new LogPeriodButton(DApplication::translate("Button", "All"), this);
+    m_allBtn->setAccessibleName("allBtn");
     m_allBtn->setToolTip(DApplication::translate("Button", "All"));  // add by Airy for bug 16245
     m_btnGroup->addButton(m_allBtn, 0);
     m_todayBtn = new LogPeriodButton(DApplication::translate("Button", "Today"), this);
+    m_todayBtn->setAccessibleName("todayBtn");
     m_todayBtn->setToolTip(DApplication::translate("Button", "Today"));  // add by Airy for bug
     m_btnGroup->addButton(m_todayBtn, 1);
     m_threeDayBtn = new LogPeriodButton(DApplication::translate("Button", "3 days"), this);
+    m_threeDayBtn->setAccessibleName("threeDayBtn");
     m_threeDayBtn->setToolTip(DApplication::translate("Button", "3 days")); // add by Airy for bug 16245
     m_btnGroup->addButton(m_threeDayBtn, 2);
     m_lastWeekBtn = new LogPeriodButton(DApplication::translate("Button", "1 week"), this);
+    m_lastWeekBtn->setAccessibleName("lastWeekBtn");
     m_lastWeekBtn->setToolTip(DApplication::translate("Button", "1 week")); // add by Airy for bug 16245
     m_btnGroup->addButton(m_lastWeekBtn, 3);
     m_lastMonthBtn = new LogPeriodButton(DApplication::translate("Button", "1 month"), this);
+    m_lastMonthBtn->setAccessibleName("lastMonthBtn");
     m_lastMonthBtn->setToolTip(DApplication::translate("Button", "1 month")); // add by Airy for bug 16245
     m_btnGroup->addButton(m_lastMonthBtn, 4);
     m_threeMonthBtn = new LogPeriodButton(DApplication::translate("Button", "3 months"), this);
+    m_threeMonthBtn->setAccessibleName("threeMonthBtn");
     m_threeMonthBtn->setToolTip(DApplication::translate("Button", "3 months")); // add by Airy for bug 16245
     m_btnGroup->addButton(m_threeMonthBtn, 5);
     //设置初始时间筛选为全部
@@ -116,6 +123,7 @@ void FilterContent::initUI()
     lvTxt->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     cbx_lv = new LogCombox(this);
     //cbx_lv->view()->setAccessibleName("combobox_level_view");
+    cbx_lv->setAccessibleName("level_combox");
     cbx_lv->setMinimumWidth(LEVEL_COMBO_WIDTH);
     cbx_lv->addItems(QStringList() << DApplication::translate("ComboBox", "All")
                      << DApplication::translate("ComboBox", "Emergency")
@@ -137,6 +145,7 @@ void FilterContent::initUI()
     dnflvTxt->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     cbx_dnf_lv = new LogCombox(this);
     //cbx_dnf_lv->view()->setAccessibleName("combobox_dnflevel_view");
+    cbx_dnf_lv->setAccessibleName("dnf_level_combox");
     cbx_dnf_lv->setMinimumWidth(198);
     cbx_dnf_lv->addItem(DApplication::translate("ComboBox", "All"), DNFLVALL);
     cbx_dnf_lv->addItem(DApplication::translate("ComboBox", "Super critical"), SUPERCRITICAL);
@@ -153,9 +162,10 @@ void FilterContent::initUI()
     // set all files under ~/.cache/deepin
     QHBoxLayout *hLayout_app = new QHBoxLayout;
     appTxt = new DLabel(DApplication::translate("Label", "Application:"), this);
+    appTxt->setAccessibleName("appLabel");
     cbx_app = new LogCombox(this);
     //cbx_app->view()->setAccessibleName("combobox_app_view");
-
+    cbx_app->setAccessibleName("app_combox");
     cbx_app->setMinimumWidth(160);
     hLayout_app->addWidget(appTxt);
     hLayout_app->addWidget(cbx_app, 1);
@@ -165,9 +175,10 @@ void FilterContent::initUI()
     // app submodules
     QHBoxLayout *hLayout_submodule = new QHBoxLayout;
     submoduleTxt = new DLabel(DApplication::translate("Label", "Submodule:"), this);
+    submoduleTxt->setAccessibleName("submoduleLabel");
     cbx_submodule = new LogCombox(this);
     //cbx_submodule->view()->setAccessibleName("combobox_submodule_view");
-
+    cbx_submodule->setAccessibleName("submodule_combox");
     cbx_submodule->setMinimumWidth(143);
     hLayout_submodule->addWidget(submoduleTxt);
     hLayout_submodule->addWidget(cbx_submodule, 1);
@@ -178,8 +189,10 @@ void FilterContent::initUI()
     // add status item
     QHBoxLayout *hLayout_status = new QHBoxLayout;
     statusTxt = new DLabel(DApplication::translate("Label", "Status:"), this);
+    statusTxt->setAccessibleName("statusLabel");
     cbx_status = new LogCombox(this);
     //cbx_status->view()->setAccessibleName("combobox_status_view");
+    cbx_status->setAccessibleName("status_combox");
     cbx_status->setMinimumWidth(120);
     cbx_status->addItems(QStringList() << DApplication::translate("ComboBox", "All") << "OK"
                          << "Failed");
@@ -191,8 +204,10 @@ void FilterContent::initUI()
     // add by Airy for adding type item
     QHBoxLayout *hLayout_type = new QHBoxLayout;
     typeTxt = new DLabel(DApplication::translate("Label", "Event Type:"), this);
+    typeTxt->setAccessibleName("eventTypeLabel");
     typeCbx = new LogCombox(this);
     //typeCbx->view()->setAccessibleName("combobox_eventtype_view");
+    typeCbx->setAccessibleName("event_type_combox");
     typeCbx->setMinimumWidth(120);
     typeCbx->addItems(QStringList() << DApplication::translate("ComboBox", "All")
                       << DApplication::translate("ComboBox", "Login")
@@ -206,7 +221,9 @@ void FilterContent::initUI()
     // 审计日志审计类型筛选下拉框
     QHBoxLayout *hLayout_auditType = new QHBoxLayout;
     auditTypeTxt = new DLabel(DApplication::translate("Label", "Audit Type:"), this);
+    auditTypeTxt->setAccessibleName("auditTypeLabel");
     auditTypeCbx = new LogCombox(this);
+    auditTypeCbx->setAccessibleName("audit_type_combox");
     auditTypeCbx->setMinimumWidth(120);
     auditTypeCbx->addItems(QStringList() << DApplication::translate("ComboBox", "All")
                       << DApplication::translate("ComboBox", "Identity authentication")
@@ -222,6 +239,7 @@ void FilterContent::initUI()
 
     hLayout_all->addStretch(1);
     exportBtn = new LogNormalButton(DApplication::translate("Button", "Export", "button"), this);
+    exportBtn->setAccessibleName("exportBtn");
     exportBtn->setContentsMargins(0, 0, 18, 18);
     exportBtn->setFixedWidth(BUTTON_EXPORT_WIDTH_MIN);
     hLayout_all->addWidget(exportBtn);

--- a/application/logcollectormain.cpp
+++ b/application/logcollectormain.cpp
@@ -168,6 +168,7 @@ void LogCollectorMain::initUI()
     m_vLayout->addWidget(m_topRightWgt);
     /** midRight frame */
     m_midRightWgt = new DisplayContent();
+    m_midRightWgt->setAccessibleName("displayWidget");
 
     m_vLayout->addWidget(m_midRightWgt, 1);
     m_vLayout->setContentsMargins(0, 10, 0, 10);

--- a/test/at/spi/expected_names.yaml
+++ b/test/at/spi/expected_names.yaml
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# AT-SPI 预期元素名称清单
+# 生成方式：libclang AST 扫描 + 源码补全
+# 生成日期：2026-08-06
+# 仓库：linuxdeepin/deepin-log-viewer (master)
+
+application: deepin-log-viewer
+
+widgets:
+  # 主窗口
+  - name: LogCollectorMain
+    type: window
+    accessible_name: ""
+    object_name: ""
+    role: Form
+
+  # 标题栏
+  - name: titlebar
+    type: titlebar
+    accessible_name: ""
+    object_name: titlebar
+
+  # 搜索框
+  - name: searchEdt
+    type: search_edit
+    accessible_name: ""
+    object_name: searchEdt
+
+  - name: searchChildEdt
+    type: line_edit
+    accessible_name: ""
+    object_name: searchChildEdt
+
+  # 左侧日志类型选择器
+  - name: logTypeSelectList
+    type: list_view
+    accessible_name: left_side_bar
+    object_name: logTypeSelectList
+    items:
+      - text: System Journal
+        data: "journal"
+      - text: Kernel Log
+        data: "kern"
+      - text: Boot Log
+        data: "boot"
+      - text: dpkg Log
+        data: "dpkg"
+      - text: Xorg Log
+        data: "xorg"
+      - text: Kwin Log
+        data: "kwin"
+      - text: Application Log
+        data: "app"
+      - text: Coredump Log
+        data: "coredump"
+      - text: Boot-Shutdown Event
+        data: "last"
+      - text: Auth Log
+        data: "auth"
+      - text: Audit Log
+        data: "audit"
+      - text: Other Log
+        data: "other"
+      - text: Custom Log
+        data: "custom"
+
+  # 主数据表格
+  - name: mainLogTable
+    type: tree_view
+    accessible_name: mainLogTable
+    object_name: mainLogTable
+
+  # 筛选面板
+  - name: FilterContent
+    type: frame
+    accessible_name: filterWidget
+    object_name: FilterContent
+    children:
+      # 时间筛选按钮
+      - name: allBtn
+        type: button
+        accessible_name: allBtn
+        text: All
+      - name: todayBtn
+        type: button
+        accessible_name: todayBtn
+        text: Today
+      - name: threeDayBtn
+        type: button
+        accessible_name: threeDayBtn
+        text: 3 days
+      - name: lastWeekBtn
+        type: button
+        accessible_name: lastWeekBtn
+        text: 1 week
+      - name: lastMonthBtn
+        type: button
+        accessible_name: lastMonthBtn
+        text: 1 month
+      - name: threeMonthBtn
+        type: button
+        accessible_name: threeMonthBtn
+        text: 3 months
+
+      # 提示标签（原有名称保持不动）
+      - name: periodLabel
+        type: label
+        accessible_name: periodLabel
+      - name: levelLabel
+        type: label
+        accessible_name: "Level:  "
+      - name: dnfLevelLabel
+        type: label
+        accessible_name: "dnfLevel:  "
+      - name: appLabel
+        type: label
+        accessible_name: appLabel
+      - name: submoduleLabel
+        type: label
+        accessible_name: submoduleLabel
+      - name: statusLabel
+        type: label
+        accessible_name: statusLabel
+      - name: eventTypeLabel
+        type: label
+        accessible_name: eventTypeLabel
+      - name: auditTypeLabel
+        type: label
+        accessible_name: auditTypeLabel
+
+      # 下拉筛选框（原有名称保持不动）
+      - name: levelCombox
+        type: combobox
+        accessible_name: level_combox
+        object_name: level_combox
+      - name: dnfLevelCombox
+        type: combobox
+        accessible_name: dnf_level_combox
+      - name: appCombox
+        type: combobox
+        accessible_name: app_combox
+        object_name: app_combox
+      - name: submoduleCombox
+        type: combobox
+        accessible_name: submodule_combox
+      - name: statusCombox
+        type: combobox
+        accessible_name: status_combox
+        object_name: status_combox
+      - name: eventTypeCombox
+        type: combobox
+        accessible_name: event_type_combox
+        object_name: event_type_combox
+      - name: auditTypeCombox
+        type: combobox
+        accessible_name: audit_type_combox
+
+      # 导出按钮
+      - name: exportBtn
+        type: button
+        accessible_name: exportBtn
+        text: Export
+
+  # 内容显示面板
+  - name: DisplayContent
+    type: widget
+    accessible_name: displayWidget
+    object_name: DisplayContent
+    children:
+      - name: splitterFrame
+        type: splitter
+        accessible_name: splitterFrame
+      - name: spinnerWidget
+        type: spinner
+        accessible_name: spinnerWidget
+      - name: spinnerWidgetK
+        type: spinner
+        accessible_name: spinnerWidget_K
+      - name: detailInfoWidget
+        type: detail_widget
+        accessible_name: detailInfoWidget
+      - name: noResultLabel
+        type: label
+        accessible_name: noResultLabel
+      - name: notAuditLabel
+        type: label
+        accessible_name: notAuditLabel
+      - name: noCoredumpctlLabel
+        type: label
+        accessible_name: noCoredumpctlLabel
+      - name: noPermissionLabel
+        type: label
+        accessible_name: noPermissionLabel
+
+  # 详情信息面板
+  - name: logDetailInfoWidget
+    type: detail_widget
+    accessible_name: detailInfoWidget
+
+  # 导出进度对话框
+  - name: exportProgressDlg
+    type: dialog
+    accessible_name: ExportProgressDlg
+
+  # 表格右键菜单
+  - name: tableMenu
+    type: menu
+    accessible_name: table_menu
+    items:
+      - text: Display in file manager
+      - text: Refresh
+
+  # 标题栏按钮（原有名称保持翻译字符串）
+  - name: exportAllBtn
+    type: icon_button
+    accessible_name: "Export All"
+  - name: refreshBtn
+    type: icon_button
+    accessible_name: "Refresh Now"
+
+  # 标题栏刷新间隔菜单
+  - name: refreshIntervalMenu
+    type: menu
+    accessible_name: refresh_interval_menu
+    items:
+      - text: 10 sec
+      - text: 1 min
+      - text: 5 min
+      - text: No refresh
+
+  # 中央控件
+  - name: centralWidget
+    type: widget
+    accessible_name: centralWidget


### PR DESCRIPTION
## Summary

完成 deepin-log-viewer 的 AT-SPI 可访问性补全，为所有自定义控件类注册 Accessible 接口，并补充 missing setAccessibleName() 调用。

## 改动清单

1. **application/accessible.h**: 为所有自定义控件类添加 Accessible 接口定义和注册（LogListView、LogTreeView、LogCombox、LogPeriodButton、LogNormalButton、LogIconButton、LogSpinnerWidget、logDetailInfoWidget、logDetailEdit、ExportProgressDlg、FilterContent、DisplayContent、LogCollectorMain、LogTableView）
2. **application/filtercontent.cpp**: 为各筛选控件添加 setAccessibleName()（时间按钮、下拉框、标签、导出按钮）
3. **application/displaycontent.cpp**: 为提示标签添加 setAccessibleName()
4. **application/logcollectormain.cpp**: 为 DisplayContent 添加 accessibleName
5. **test/at/spi/expected_names.yaml**: 新增 AT-SPI 预期元素清单参考基线文件（新增）

## 编译验证

所有 application 源码文件（包括 main.cpp、filtercontent.cpp、displaycontent.cpp、logcollectormain.cpp 等）已通过编译验证。

## 相关 Issue

V-1558

## Summary by Sourcery

Improve AT-SPI accessibility coverage across deepin-log-viewer widgets and dialogs.

Enhancements:
- Register all custom log viewer widgets and dialogs with the Qt accessibility factory so they expose appropriate AT-SPI roles and names.
- Assign explicit accessible names to filter panel controls and display content labels to make them identifiable to assistive technologies.
- Expose the main display content widget via an accessible name from the main window layout.

Tests:
- Add an AT-SPI expected element name baseline YAML to document and validate the accessible structure and naming of key widgets.