### PR TITLE
fix(security): authorize whiteListOutPaths D-Bus method

### DIFF
--- a/application/logbackend.cpp
+++ b/application/logbackend.cpp
@@ -694,8 +694,6 @@ QStringList LogBackend::getLogTypes()
     //auth
     m_logTypes.push_back(AUTH_TREE_DATA);
 
-    DLDBusHandler::instance(qApp)->whiteListOutPaths();
-
     return m_logTypes;
 }
 
@@ -2102,6 +2100,10 @@ bool LogBackend::getOutDirPath(const QString &path)
 
         // 导出路径白名单检查
         QStringList availablePaths =  DLDBusHandler::instance()->whiteListOutPaths();
+        if (availablePaths.isEmpty()) {
+            qCWarning(logApp) << "Failed to retrieve white list out paths, aborting export pre-check";
+            return false;
+        }
         bool bAvailable = false;
         for (auto path : availablePaths) {
             if (tmpPath.startsWith(path)) {

--- a/application/logcollectormain.cpp
+++ b/application/logcollectormain.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -354,6 +354,11 @@ void LogCollectorMain::exportAllLogs()
     QFileInfo info(newPath);
     QString outPath = info.path();
     QStringList availablePaths =  DLDBusHandler::instance(this)->whiteListOutPaths();
+
+    if (availablePaths.isEmpty()) {
+        qCWarning(logApp) << "Failed to retrieve white list out paths, aborting export pre-check";
+        return;
+    }
 
     bool bAvailable = false;
     for (auto path : availablePaths) {

--- a/application/loglistview.cpp
+++ b/application/loglistview.cpp
@@ -347,9 +347,6 @@ void LogListView::initUI()
         initCustomLogItem();
     }
 
-
-    DLDBusHandler::instance(this)->whiteListOutPaths();
-
     // set first item is select when app start
     if (m_pModel->rowCount() > 0) {
         this->setCurrentIndex(m_pModel->index(0, 0));

--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -833,6 +833,9 @@ QStringList LogViewerService::whiteListOutPaths()
 {
     trackCurrentCaller();
     qCDebug(logService) << "Getting white list out paths";
+    if (!checkAuth(s_Action_View)) {
+        return {};
+    }
     QStringList paths;
     // 获取用户家目录
     QStringList homeList = getHomePaths();


### PR DESCRIPTION
## 根因分析

`LogViewerService::whiteListOutPaths()`（`logViewerService/logviewerservice.cpp`）是以 root 运行的 D-Bus 系统服务 `com.deepin.logviewer` 对外暴露的方法，**缺少调用者鉴权**——仅有 `trackCurrentCaller()`，无 `checkAuth()`、无 caller-uid 校验。任意本地未授权进程可直接调用，拿到导出白名单路径（全部 `/home/*` 用户家目录、外设/SMB 挂载点、`/tmp`），构成信息泄露。它是该服务 13 个对外 D-Bus 方法中**唯一**缺鉴权的，缺口源自安全加固提交 `adb455a`（BUG-372481）补 `trackCurrentCaller()` 时漏配 `checkAuth()`。结论级别：强根因。

关键证据：
- `logViewerService/logviewerservice.cpp:832` — `whiteListOutPaths()` 仅有 `trackCurrentCaller()`，无 `checkAuth()`，直接 `return paths`。
- 对照其余 12 个对外 D-Bus 方法（`getFileSize`/`getFileInfo`/`getLineCount`/`executeCmd`/`exportLog`…）均在 `trackCurrentCaller()` 后紧跟 `if(!checkAuth(s_Action_View)) {...}`，本方法是唯一例外。
- 与 PMS 历史备注（王荣 2026-08-05："没有进行调用者身份验证"）完全吻合。

## 修复方案

1. 为 `whiteListOutPaths` 补 `if (!checkAuth(s_Action_View)) { return {}; }` 鉴权门禁，鉴权失败返回空列表（fail-closed），与 `getFileInfo`/`getFileSize` 等 12 个对外 D-Bus 方法完全同构。服务内 `exportLog → whiteListOutPaths` 白名单校验正常工作——`exportLog` 已在自身入口鉴权，且 `calledFromDBus()` 在 D-Bus 分发上下文中对内部调用仍为真，`checkAuth` 正常执行、polkit 缓存命中，无需额外守卫。
2. 删除前端两处「调用但不接收返回值」的死调用（`application/logbackend.cpp` 的 `LogBackend::getLogTypes()`、`application/loglistview.cpp` 的 `LogListView::initUI()`），避免补鉴权后对普通用户触发不必要的 polkit 弹框；保留两处使用返回值的导出流程调用。
3. 为两处保留的前端调用补充空列表错误处理：`whiteListOutPaths()` 返回空（鉴权/D-Bus 失败）时打 `qWarning` 并中止导出前置校验，不再显示误导性的「导出目录不可用」提示；服务端 `exportLog` 仍对已鉴权调用者做权威白名单校验，安全性不受影响。

改动：4 文件，+12 / −5。不涉及函数签名/类成员变更。

## 改动安全评估

风险等级：**低风险**。仅在已有 D-Bus 入口追加 early-return 鉴权门禁（与 12 个同类方法同构）+ 删除 2 处死调用；不改变签名、不删除公开方法、不修改类成员。服务内部 `exportLog → whiteListOutPaths` 链路在 `exportLog` 入口已 `checkAuth`，二次检查同调用者走 polkit `auth_admin_keep` 缓存，不破坏导出、不双重弹框。详见附件 `change-safety.md`。

## 关联

- PMS: https://pms.uniontech.com/bug-view-370885.html
- 根因分析报告全文见附件 `analysis-report.md`

## Summary by Sourcery

Add authorization checks to the whiteListOutPaths D-Bus method and harden its use in the export flow.

Bug Fixes:
- Protect the whiteListOutPaths D-Bus method with an authorization check to prevent unauthorized access to export whitelist paths.

Enhancements:
- Remove unused frontend calls to whiteListOutPaths that ignored its return value to avoid unnecessary authorization prompts.
- Add error handling in export-related frontend code when whiteListOutPaths returns an empty list, aborting the export pre-check instead of proceeding with misleading messages.