### PR TITLE
chore: Bump version to 6.5.35

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+deepin-log-viewer (6.5.35) unstable; urgency=medium
+
+  * fix(security): add polkit auth check to getFileSize D-Bus method
+  * fix(security): restrict quit to root, auto-exit when no D-Bus
+    clients
+  * fix(security): authorize whiteListOutPaths D-Bus method
+
+ -- wangrong <wangrong@uniontech.com>  Fri, 07 Aug 2026 09:50:23 +0800
+
 deepin-log-viewer (6.5.34) unstable; urgency=medium
 
   * chore: Update version to 6.5.34


### PR DESCRIPTION
As title.

Log: Bump version to 6.5.35

## Summary by Sourcery

Chores:
- Update Debian changelog entry to reflect version 6.5.35.