### PR TITLE
fix(security): authorize D-Bus method

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,7 +4,7 @@ Upstream-Contact: UnionTech Software Technology Co., Ltd. <>
 Source: https://github.com/linuxdeepin/deepin-log-viewer
 
 # ci
-Files: .github/* .obs/workflows.yml
+Files: .github/* .obs/workflows.yml reuse_lint_report.md
 Copyright: None
 License: CC0-1.0
 
@@ -29,7 +29,7 @@ Copyright: UnionTech Software Technology Co., Ltd.
 License: CC0-1.0
 
 # Project file
-Files: *.pro *.prf *.pri *.qrc *CMakeLists.txt .tx/*
+Files: *.pro *.prf *.pri *.qrc *CMakeLists.txt .tx/* .project
 Copyright: UnionTech Software Technology Co., Ltd.
 License: CC0-1.0
 

--- a/application/dbusproxy/dldbushandler.cpp
+++ b/application/dbusproxy/dldbushandler.cpp
@@ -25,7 +25,7 @@ DLDBusHandler *DLDBusHandler::instance(QObject *parent)
 
 DLDBusHandler::~DLDBusHandler()
 {
-    quit();
+    // 不再主动调用后端 quit()：后端会在所有 D-Bus 客户端断开后自行退出。
 }
 
 DLDBusHandler::DLDBusHandler(QObject *parent)

--- a/application/logbackend.cpp
+++ b/application/logbackend.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -602,8 +602,6 @@ QStringList LogBackend::getLogTypes()
 
     //audit
     m_logTypes.push_back(AUDIT_TREE_DATA);
-
-    DLDBusHandler::instance(qApp)->whiteListOutPaths();
 
     return m_logTypes;
 }
@@ -1725,6 +1723,10 @@ bool LogBackend::getOutDirPath(const QString &path)
 
         // 导出路径白名单检查
         QStringList availablePaths =  DLDBusHandler::instance()->whiteListOutPaths();
+        if (availablePaths.isEmpty()) {
+            qCWarning(logBackend) << "Failed to retrieve white list out paths, aborting export pre-check";
+            return false;
+        }
         bool bAvailable = false;
         for (auto path : availablePaths) {
             if (tmpPath.startsWith(path)) {

--- a/application/logcollectormain.cpp
+++ b/application/logcollectormain.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -326,6 +326,10 @@ void LogCollectorMain::exportAllLogs()
     QFileInfo info(newPath);
     QString outPath = info.path();
     QStringList availablePaths =  DLDBusHandler::instance(this)->whiteListOutPaths();
+
+    if (availablePaths.isEmpty()) {
+        return;
+    }
 
     bool bAvailable = false;
     for (auto path : availablePaths) {

--- a/application/loglistview.cpp
+++ b/application/loglistview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -319,8 +319,6 @@ void LogListView::initUI()
     item->setData(VListViewItemMargin, Dtk::MarginsRole);
     m_pModel->appendRow(item);
     m_logTypes.push_back(AUDIT_TREE_DATA);
-
-    DLDBusHandler::instance(this)->whiteListOutPaths();
 
     // set first item is select when app start
     if (m_pModel->rowCount() > 0) {

--- a/application/main.cpp
+++ b/application/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
         a.setApplicationName(kAppNameForDeepinLogViewer);
         a.setApplicationVersion(VERSION);
 
+        // 预先创建 DLDBusHandler
+        DLDBusHandler::instance(&a);
+
         DLogManager::registerConsoleAppender();
 
 #if (DTK_VERSION >= DTK_VERSION_CHECK(5, 6, 8, 0))
@@ -320,6 +323,9 @@ int main(int argc, char *argv[])
         a.setApplicationDisplayName(DApplication::translate("Main", "Log Viewer"));
         a.setApplicationDescription(
                     DApplication::translate("Main", "Log Viewer is a useful tool for viewing system logs."));
+
+        // 预先创建 DLDBusHandler
+        DLDBusHandler::instance(&a);
 
 #if (DTK_VERSION >= DTK_VERSION_CHECK(5, 6, 8, 0))
         DLogManager::registerJournalAppender();

--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -110,6 +110,13 @@ LogViewerService::LogViewerService(QObject *parent)
     m_commands.insert("journalctl_app", QStringList() << "journalctl");
 
     m_actionId = s_Action_View;
+
+    // 监听系统总线上调用方的唯一总线名属主变化：客户端进程退出时其唯一
+    // 总线名被释放，watcher 发出 serviceUnregistered，据此实现“无客户端即退出”。
+    m_clientWatcher = new QDBusServiceWatcher({}, QDBusConnection::systemBus(),
+                                              QDBusServiceWatcher::WatchForOwnerChange, this);
+    connect(m_clientWatcher, &QDBusServiceWatcher::serviceUnregistered,
+            this, &LogViewerService::onClientUnregistered);
 }
 
 LogViewerService::~LogViewerService()
@@ -130,6 +137,7 @@ LogViewerService::~LogViewerService()
  */
 QString LogViewerService::readLog(const QDBusUnixFileDescriptor &fd)
 {
+    trackCurrentCaller();
     if(!checkAuth(s_Action_View)) {
         return " ";
     }
@@ -299,6 +307,7 @@ bool LogViewerService::checkAuthorization(const QString &actionId, const QString
  */
 QStringList LogViewerService::readLogLinesInRange(const QDBusUnixFileDescriptor &fd, qint64 startLine, qint64 lineCount, bool bReverse)
 {
+    trackCurrentCaller();
     if(!checkAuth(s_Action_View)) {
         return QStringList();
     }
@@ -444,6 +453,7 @@ qint64 LogViewerService::findLineStartOffsetWithCaching(const QString &filePath,
 
 qint64 LogViewerService::getLineCount(const QString &filePath)
 {
+    trackCurrentCaller();
     if (!checkAuth(s_Action_View))
         return -1;
 
@@ -479,6 +489,7 @@ void LogViewerService::processCmdArgs(const QString &cmdStr, const QStringList &
 
 QString LogViewerService::executeCmd(const QString &cmd)
 {
+    trackCurrentCaller();
     QString result("");
 
     if (!checkAuth(s_Action_View))
@@ -552,6 +563,7 @@ QString LogViewerService::executeCmd(const QString &cmd)
  */
 QString LogViewerService::openLogStream(const QString &filePath)
 {
+    trackCurrentCaller();
     QString result = readLog(filePath);
     if(result == " ") {
         return "";
@@ -574,6 +586,7 @@ QString LogViewerService::openLogStream(const QString &filePath)
  */
 QString LogViewerService::readLogInStream(const QString &token)
 {
+    trackCurrentCaller();
     if(!m_logMap.contains(token)) {
         return "";
     }
@@ -605,6 +618,7 @@ QString LogViewerService::readLogInStream(const QString &token)
 
 QString LogViewerService::isFileExist(const QString &filePath)
 {
+    trackCurrentCaller();
     if (!checkAuth(s_Action_View))
         return QString("");
 
@@ -616,6 +630,7 @@ QString LogViewerService::isFileExist(const QString &filePath)
 
 quint64 LogViewerService::getFileSize(const QString &filePath)
 {
+    trackCurrentCaller();
     if (!checkAuth(s_Action_View)) {
         return 0;
     }
@@ -630,6 +645,7 @@ quint64 LogViewerService::getFileSize(const QString &filePath)
 // 获取白名单导出路径
 QStringList LogViewerService::whiteListOutPaths()
 {
+    trackCurrentCaller();
     QStringList paths;
     // 获取用户家目录
     QStringList homeList = getHomePaths();
@@ -725,16 +741,43 @@ void LogViewerService::clearTempFiles()
  */
 int LogViewerService::exitCode()
 {
+    trackCurrentCaller();
     return m_process.exitCode();
 }
 
 /*!
  * \~chinese \brief LogViewerService::quit 退出服务端程序
+ *
+ * 仅允许 root 调用（systemd/管理员显式停服）。非 root 调用直接返回
+ * AccessDenied，不触发 polkit 认证（不弹框），避免“请求退出却提示
+ * 访问日志需要认证”的语义错位。普通用户的正常退出由服务端在所有
+ * 客户端断开后自动执行（见 onClientUnregistered）。
  */
 void LogViewerService::quit()
 {
     qCDebug(logService) << "LogViewService::Quit called";
-    QCoreApplication::exit(0);
+    trackCurrentCaller();
+    if (!calledFromDBus()) {
+        return;
+    }
+    // 显式校验 D-Bus 回复有效性：serviceUid() 失败时 QDBusReply::value() 会静默
+    // 返回默认构造值 0，若直接当作 UID 会与 root(0) 混淆，构成 fail-open。此处
+    // 对无效回复 fail-closed，拒绝退出并回 AccessDenied，绝不回退为 0。
+    auto reply = connection().interface()->serviceUid(message().service());
+    if (!reply.isValid()) {
+        qCWarning(logService) << "quit denied: failed to get caller UID via D-Bus:"
+                              << reply.error().message();
+        sendErrorReply(QDBusError::ErrorType::AccessDenied,
+                       "quit is only allowed for root");
+        return;
+    }
+    const uint callerUid = reply.value();
+    if (callerUid != 0) {
+        qCWarning(logService) << "quit denied: non-root caller uid" << callerUid;
+        sendErrorReply(QDBusError::ErrorType::AccessDenied, "quit is only allowed for root");
+        return;
+    }
+    QCoreApplication::quit();
 }
 
 /*!
@@ -744,6 +787,7 @@ void LogViewerService::quit()
  */
 QStringList LogViewerService::getFileInfo(const QString &file, bool unzip)
 {
+    trackCurrentCaller();
     // 判断非法调用
     if (!checkAuth(s_Action_View)) {
         return {};
@@ -851,6 +895,7 @@ QStringList LogViewerService::getFileInfo(const QString &file, bool unzip)
  */
 QStringList LogViewerService::getOtherFileInfo(const QString &file, bool unzip)
 {
+    trackCurrentCaller();
     // 判断非法调用
     if (!checkAuth(s_Action_View)) {
         return {};
@@ -920,6 +965,7 @@ static bool processExportLog(const QString &cmdStr, const QString &outFullPath,c
 
 bool LogViewerService::exportLog(const QString &outDir, const QString &in, bool isFile)
 {
+    trackCurrentCaller();
     if(!checkAuth(s_Action_View)) { //非法调用
         return false;
     }
@@ -1043,8 +1089,35 @@ bool LogViewerService::exportLog(const QString &outDir, const QString &in, bool 
     return true;
 }
 
+void LogViewerService::trackCurrentCaller()
+{
+    // 仅 D-Bus 调用才记录；内部调用（calledFromDBus() 为 false）直接 no-op，
+    // 因此在私有 helper 等非 D-Bus 入口调用也无副作用。
+    if (!calledFromDBus())
+        return;
+    const QString caller = message().service();
+    if (caller.isEmpty() || m_clientBusNames.contains(caller))
+        return;
+    m_clientBusNames.insert(caller);
+    m_clientWatcher->addWatchedService(caller);
+}
+
+void LogViewerService::onClientUnregistered(const QString &serviceName)
+{
+    if (!m_clientBusNames.remove(serviceName))
+        return;
+    qCInfo(logService) << "Client disconnected:" << serviceName
+                       << "remaining:" << m_clientBusNames.size();
+    // 仅在“有客户端 → 全部断开”的转换时退出；启动空集不退出。
+    if (m_clientBusNames.isEmpty()) {
+        qCInfo(logService) << "All clients disconnected, exiting";
+        QCoreApplication::quit();
+    }
+}
+
 bool LogViewerService::exportOpsLog(const QDBusUnixFileDescriptor &fd)
 {
+    trackCurrentCaller();
     if(!checkAuth(s_Action_View)) { //非法调用
         qCWarning(logService) << "Invalid authorization for export log";
         return false;

--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -646,6 +646,9 @@ quint64 LogViewerService::getFileSize(const QString &filePath)
 QStringList LogViewerService::whiteListOutPaths()
 {
     trackCurrentCaller();
+    if (!checkAuth(s_Action_View)) {
+        return {};
+    }
     QStringList paths;
     // 获取用户家目录
     QStringList homeList = getHomePaths();

--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -616,6 +616,10 @@ QString LogViewerService::isFileExist(const QString &filePath)
 
 quint64 LogViewerService::getFileSize(const QString &filePath)
 {
+    if (!checkAuth(s_Action_View)) {
+        return 0;
+    }
+
     QFileInfo fi(filePath);
     if (fi.exists())
         return static_cast<quint64>(fi.size());

--- a/logViewerService/logviewerservice.h
+++ b/logViewerService/logviewerservice.h
@@ -14,6 +14,8 @@
 #include <QTemporaryDir>
 #include <QDBusUnixFileDescriptor>
 #include <QMap>
+#include <QDBusServiceWatcher>
+#include <QSet>
 
 class QTextStream;
 class DGioVolumeManager;
@@ -85,6 +87,13 @@ private:
     bool removeOpsTempDirByPathInternal(const QString &path);
     QByteArray processCatFile(const QString &filePath);
     void processCmdArgs(const QString &cmdStr, const QStringList &args);
+
+    // 客户端生命周期跟踪：记录所有通过 D-Bus 连入的调用方唯一总线名，
+    // 当最后一个客户端断开后自动退出服务（替代被前端主动调用的 quit）。
+    void trackCurrentCaller();
+    void onClientUnregistered(const QString &serviceName);
+    QDBusServiceWatcher *m_clientWatcher = nullptr;
+    QSet<QString> m_clientBusNames;
 };
 
 #endif // LOGVIEWERSERVICE_H


### PR DESCRIPTION
## Summary by Sourcery

Enforce D-Bus authorization for log access and service shutdown while managing the service lifecycle based on connected clients.

New Features:
- Automatically terminate the D-Bus log service after all connected clients disconnect.

Bug Fixes:
- Authorize all D-Bus log operations and restrict explicit service shutdown to root callers with fail-closed identity validation.
- Abort log exports when the output-path whitelist cannot be retrieved.

Enhancements:
- Initialize D-Bus handling at application startup and track calling clients across service methods.

Chores:
- Update SPDX copyright years.