### PR TITLE
fix(service): validate QDBusReply in checkAuth to prevent Polkit bypass

### DIFF
--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -1383,7 +1383,18 @@ bool LogViewerService::checkAuth(const QString &actionId)
         return false;
     }
 
-    bool isRoot = connection().interface()->serviceUid(message().service()).value() == 0;
+    // 显式校验 D-Bus 回复有效性：serviceUid() 失败时 QDBusReply::value() 会静默
+    // 返回默认构造值 0，若直接当作 UID 会与 root(0) 混淆，构成 fail-open——
+    // 任何 D-Bus 调用者都能借此绕过 Polkit 被当作 root 放行。此处对无效回复
+    // fail-closed，拒绝访问并回 Failed，绝不回退为 root。
+    auto reply = connection().interface()->serviceUid(message().service());
+    if (!reply.isValid()) {
+        qCWarning(logService) << "checkAuth denied: failed to get caller UID via D-Bus:"
+                              << reply.error().message();
+        sendErrorReply(QDBusError::ErrorType::Failed, "failed to get caller UID");
+        return false;
+    }
+    bool isRoot = reply.value() == 0;
     if (isRoot) {
         qCInfo(logService) << "dbus caller is root progress.";
         return  true;


### PR DESCRIPTION
Explicitly check QDBusReply::isValid() before reading serviceUid() in checkAuth(). On D-Bus failure, value() silently returns 0, colliding with root's UID and letting any caller bypass Polkit as root.

显式校验 serviceUid() 的 QDBusReply 有效性，失败时 fail-closed。 原代码在 D-Bus 回复无效时 value() 静默返回 0，与 root UID 混淆，
任意 D-Bus 调用者可借此绕过 Polkit 被当作 root 放行。

Log: 修复checkAuth未校验D-Bus回复导致鉴权绕过
PMS: BUG-373483
Influence: 修复后服务端鉴权失败时拒绝访问，不再回退为root，消除本地提权风险。

## Summary by Sourcery

Bug Fixes:
- Validate the QDBusReply from serviceUid() in checkAuth and fail closed on invalid D-Bus replies to prevent Polkit bypass and local privilege escalation.