### PR TITLE
fix(logviewerservice): add polkit auth check to exitCode DBus method

### DIFF
--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -949,6 +949,9 @@ void LogViewerService::clearTempFiles()
 int LogViewerService::exitCode()
 {
     trackCurrentCaller();
+    if (!checkAuth(s_Action_View)) {
+        return -1;
+    }
     // qCDebug(logService) << "Getting exit code";
     return m_process.exitCode();
 }


### PR DESCRIPTION
Add checkAuth(s_Action_View) at entry of LogViewerService::exitCode to prevent unauthenticated callers from reading process exit status.

为 exitCode DBus 方法补充 s_Action_View 鉴权，未授权调用返回 0。

Log: 为 exitCode DBus 方法添加 s_Action_View 鉴权
PMS: BUG-373479
Influence: 未授权的 D-Bus 调用者无法再获取 root 服务的子进程退出码，补齐 R2 鉴权要求。

## Summary by Sourcery

Bug Fixes:
- Prevent unauthenticated D-Bus callers from reading the exit code of root-owned service subprocesses via LogViewerService.