### PR TITLE
fix: gate coredump report watermark on event-log backend availability (PMS 336769)

### DIFF
--- a/application/eventlogutils.cpp
+++ b/application/eventlogutils.cpp
@@ -8,6 +8,13 @@
 #include <QLibraryInfo>
 #include <QJsonDocument>
 #include <QThread>
+#include <QLoggingCategory>
+
+#ifdef QT_DEBUG
+Q_LOGGING_CATEGORY(logEventUtils, "org.deepin.log.viewer.eventutils")
+#else
+Q_LOGGING_CATEGORY(logEventUtils, "org.deepin.log.viewer.eventutils", QtInfoMsg)
+#endif
 
 Eventlogutils *Eventlogutils::m_pInstance = nullptr;
 Eventlogutils *Eventlogutils::GetInstance()
@@ -20,20 +27,39 @@ Eventlogutils *Eventlogutils::GetInstance()
 
 void Eventlogutils::writeLogs(QJsonObject &data)
 {
-    if (!writeEventLogFunc)
+    if (!writeEventLogFunc) {
+        qCWarning(logEventUtils) << "writeEventLogFunc is null, skip writing event log";
         return;
+    }
 
     writeEventLogFunc(QJsonDocument(data).toJson(QJsonDocument::Compact).toStdString());
 }
 
 Eventlogutils::Eventlogutils()
+    : m_available(false)
 {
     QLibrary library("libdeepin-event-log.so");
     initFunc = reinterpret_cast<bool (*)(const std::string &, bool)>(library.resolve("Initialize"));
     writeEventLogFunc = reinterpret_cast<void (*)(const std::string &)>(library.resolve("WriteEventLog"));
 
-    if (!initFunc)
+    if (!initFunc) {
+        qCWarning(logEventUtils) << "Failed to resolve Initialize from libdeepin-event-log.so;"
+                                 << "crash report upload disabled, watermark will not advance until the backend is available";
         return;
+    }
 
-    initFunc("deepin-log-viewer", true);
+    if (!writeEventLogFunc) {
+        qCWarning(logEventUtils) << "Failed to resolve WriteEventLog from libdeepin-event-log.so;"
+                                 << "crash report upload disabled, watermark will not advance until the backend is available";
+    }
+
+    // Initialize 仍按原行为调用；后端可写性由 m_available 反映，供上报链路门禁使用。
+    // 注意 WriteEventLog 签名为 void，无法获知上传是否真正成功，因此 m_available 仅表示
+    // “后端已加载且初始化完成”，覆盖 .so 缺失/符号缺失/Initialize 失败三类不可用情形。
+    m_available = initFunc("deepin-log-viewer", true) && writeEventLogFunc;
+}
+
+bool Eventlogutils::isAvailable()
+{
+    return m_available;
 }

--- a/application/eventlogutils.h
+++ b/application/eventlogutils.h
@@ -20,12 +20,14 @@ public:
 
     static Eventlogutils *GetInstance();
     void writeLogs(QJsonObject &data);
+    bool isAvailable();
 private :
     static Eventlogutils *m_pInstance;
     Eventlogutils();
 
     bool (*initFunc)(const std::string &packagename, bool enable_sig) = nullptr;
     void (*writeEventLogFunc)(const std::string &eventdata) = nullptr;
+    bool m_available = false;
 };
 
 #endif // EVENTLOGUTILS_H

--- a/application/logbackend.cpp
+++ b/application/logbackend.cpp
@@ -1042,7 +1042,7 @@ void LogBackend::slot_coredumpFinished(int index)
             latestCoredumpTime = latestCoredumpTime.addSecs(1);
 
             // 先初始化埋点接口，延迟2秒后调用埋点接口，以便能正常写入埋点数据
-            Eventlogutils::GetInstance();
+            Eventlogutils *reporter = Eventlogutils::GetInstance();
 
             QTimer::singleShot(2000, this, [=]{
                 // 埋点记录崩溃数据
@@ -1056,7 +1056,18 @@ void LogBackend::slot_coredumpFinished(int index)
                     {"message", objList}
                 };
 
-                Eventlogutils::GetInstance()->writeLogs(objCoredumpEvent);
+                if (!reporter->isAvailable()) {
+                    // 埋点后端不可用（libdeepin-event-log.so 缺失或初始化失败）：不前移上报水位，
+                    // 保留本轮崩溃数据待下一周期重试，避免“静默丢数据 + 假成功”。
+                    // 退出码仍为 0，避免被 systemctl --failed 误判为失败服务。
+                    qCWarning(logBackend) << QString("Skip reporting %1 crash messages: event-log backend unavailable, "
+                                                     "watermark not advanced (will retry next cycle).")
+                                                 .arg(afterCleanData.size());
+                    qApp->exit(0);
+                    return;
+                }
+
+                reporter->writeLogs(objCoredumpEvent);
                 LogApplicationHelper::instance()->saveLastRerportTime(latestCoredumpTime);
                 qCInfo(logBackend) << QString("Successfully reported %1 crash messages in total.").arg(afterCleanData.size());
                 qApp->exit(0);

--- a/debian/control
+++ b/debian/control
@@ -7,13 +7,13 @@ Standards-Version: 4.1.3
 
 Package: deepin-log-viewer
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, deepin-event-log
 Description:Log Viewer is a useful tool for viewing system logs.
  Log viewer is a tool that collects logs generated when an application
  is running, for example, logs generated when operating system and
  applications start up and run. You can do trouble-shooting and solve
  problems quickly by analyzing logs.
-Recommends: uos-reporter, deepin-event-log    
+Recommends: uos-reporter
 
 Package: liblogviewerplugin
 Architecture: any

--- a/debian/deepin-log-viewer.postinst
+++ b/debian/deepin-log-viewer.postinst
@@ -25,6 +25,8 @@ done
 if [ -f /lib/systemd/system/coredump-reporter.timer ]; then
     systemctl daemon-reload || true
     systemctl enable coredump-reporter.timer || true
+    # 升级安装后立即激活定时器，避免重启前 coredump 上报链路不运行
+    systemctl start coredump-reporter.timer || true
 fi
 
 #确保软件包安装不会失败


### PR DESCRIPTION
## 关联

PMS: https://pms.uniontech.com/bug-view-336769.html （单号 336769）
目标分支：release/eagle（基线 `52b775169dd8e99ccc049eca7c5acf88b85411ad`）

## 根因分析（结论：强根因，已通过根因复核）

1070u3「日志收集工具无崩溃上报服务」的真实根因是**上报"成功路径"未以上传结果为门禁**：

- `Eventlogutils` 把 `libdeepin-event-log.so` 当可选后端做运行期 `QLibrary` dlopen（非构建期链接，故该包仅在 `debian/control:16` 为 `Recommends`）。加载失败时 `initFunc`/`writeEventLogFunc` 均为 nullptr，构造函数（`eventlogutils.cpp:35-36`）与 `writeLogs`（`:23-24`）静默 `return`，无任何日志。
- `LogBackend::slot_coredumpFinished` 的 Report 分支（`logbackend.cpp:1059-1062`）在调用 `writeLogs` 后**无条件**前移水位 `saveLastRerportTime` + 打印 `Successfully reported` + `exit(0)`。
- 后果：崩溃数据从未上传却显示成功、上报水位持续前移、已"上报"崩溃在下一周期增量窗口 `[lastTime, now]` 中被永久跳过，全程无错误日志。
- 复核强化：`WriteEventLog` 签名为 `void`，即便 `.so` 存在也不返回上传结果——"无门禁"是结构性缺陷，非仅由 `.so` 缺失触发。

关键证据：`eventlogutils.cpp:23-24/31-36`、`logbackend.cpp:1045/1047/1059-1062`、`debian/control:16`、`debian/deepin-log-viewer.postinst:25-27`（enable-only + `|| true`，升级不重启 timer 不激活，为另一独立失败模式）。

## 修复方案

1. **核心（代码门禁）**：`Eventlogutils` 新增 `isAvailable()`（反映 `.so` 加载且 `Initialize` 成功），coredump 上报链路仅在后端可用时才前移水位；不可用时打 `qCWarning`、不前移水位、保留本轮崩溃数据待下一周期重试，退出码仍为 0（不触犯 `systemctl --failed` 约束）。同时给 `writeLogs`/构造的静默 return 路径补告警日志（可观测性，backport master `80d0a04` 的思路）。
2. **依赖**：`debian/control` 将 `deepin-event-log` 由 `Recommends` 提升为 `Depends`，确保 1070u3 等精简镜像安装该包以提供 `libdeepin-event-log.so`，使上报链路真正可用。
3. **部署**：`postinst` 在 `enable coredump-reporter.timer` 后追加 `start`，升级安装后立即激活定时器，避免重启前上报链路不运行。

> 说明：`WriteEventLog` 为 `void`，`isAvailable()` 仅能覆盖"后端不可用"（`.so` 缺失/符号缺失/`Initialize` 失败），无法覆盖"后端可用但网络上传失败"——后者需 `deepin-event-log` 侧 API 改动，超出本包范围。同类静默 return 模式 `main.cpp:356-364`（启动埋点）不在本次范围，后续单独处理。

## 改动安全评估

低风险：`writeLogs` 签名不变（仍 `void`），仅**新增** `isAvailable()` 公共方法与 `m_available` 私有成员；门禁逻辑加在 coredump 上报单一调用点，`Initialize` 仍按原行为调用。改动仅 5 文件、+48/-7，无函数签名变更、无公开 API 删除。`saveLastRerportTime` 调用点 `6d2a2051` 的持久化重构（LogSettings→DConfig/gsettings）不被撤销，仅被门禁。

## 自测说明

未做编译验证/部署自测（按流程边界，由后续人工关口负责）。改动为 Qt 常规用法（`QLoggingCategory`、`qCWarning`），无构建系统变更。

## Summary by Sourcery

Gate coredump reporting watermark advancement on the availability of the event-log backend and ensure the backend is reliably installed and activated.

New Features:
- Expose an Eventlogutils availability check so crash reporting can be conditioned on a functioning event-log backend.

Bug Fixes:
- Prevent coredump reports from being marked successful and advancing the watermark when the event-log backend library is missing or not initialized, avoiding silent data loss.

Enhancements:
- Add logging around event-log backend resolution and write operations to improve observability when crash reporting is disabled or misconfigured.

Build:
- Change the deepin-event-log package from a recommended to a required dependency to guarantee presence of the event-log backend library.

Deployment:
- Update post-install scripts to start the coredump-reporter timer immediately after enabling it so crash reporting runs without requiring a reboot.