### PR TITLE
fix: release DConfig/QGSettings dbus threads before exit to avoid teardown race

### DIFF
--- a/application/logapplicationhelper.cpp
+++ b/application/logapplicationhelper.cpp
@@ -202,7 +202,7 @@ void LogApplicationHelper::initCustomLog()
     //初始化gsetting配置
     if (!m_pGSettings) {
         if (QGSettings::isSchemaInstalled(GSETTING_APPID.toUtf8())) {
-            m_pGSettings = new QGSettings(GSETTING_APPID.toUtf8(), "/com/deepin/log/viewer/");
+            m_pGSettings = new QGSettings(GSETTING_APPID.toUtf8(), "/com/deepin/log/viewer/", this);
 
             //监听key的value是否发生了变化
             connect(m_pGSettings, &QGSettings::changed, this, [ = ](const QString & key) {
@@ -225,6 +225,27 @@ void LogApplicationHelper::initCustomLog()
         } else {
             qCWarning(logAppHelper) << "cannot find gsettings config file";
         }
+    }
+}
+
+/**
+ * @brief LogApplicationHelper::releaseConfigs 释放 DConfig/QGSettings 对象
+ *
+ * 上报子进程完成业务后、qApp->exit(0) 前调用，使 DConfig/QGSettings 持有的
+ * 后台 dbus 子线程在 QCoreApplication 仍存活时被释放，避免进程退出析构时
+ * 与子线程 QDBusConnectionManager teardown 竞态致崩。
+ */
+void LogApplicationHelper::releaseConfigs()
+{
+#ifdef DTKCORE_CLASS_DConfigFile
+    if (m_pDConfig) {
+        delete m_pDConfig;
+        m_pDConfig = nullptr;
+    }
+#endif
+    if (m_pGSettings) {
+        delete m_pGSettings;
+        m_pGSettings = nullptr;
     }
 }
 

--- a/application/logapplicationhelper.h
+++ b/application/logapplicationhelper.h
@@ -70,6 +70,10 @@ public:
     // 获取崩溃上报最大条数，默认为50
     int getMaxReportCoredump();
 
+    // 释放 DConfig/QGSettings 对象及其后台 dbus 子线程，供上报子进程退出前确定性清理，
+    // 避免 qApp->exit(0) 时与子线程 QDBusConnectionManager 析构竞态
+    void releaseConfigs();
+
 private:
     explicit LogApplicationHelper(QObject *parent = nullptr);
 

--- a/application/logbackend.cpp
+++ b/application/logbackend.cpp
@@ -988,6 +988,8 @@ void LogBackend::slot_coredumpFinished(int index)
                                      .arg(lastTime.toString("yyyy-MM-dd hh:mm:ss"))
                                      .arg(curTime.toString("yyyy-MM-dd hh:mm:ss"));
             // 此处退出码不能为-1，否则systemctl --failed服务会将其判为失败的systemd服务
+            // 先释放 DConfig/QGSettings 后台 dbus 子线程，避免 exit(0) 析构时与子线程 QDBusConnectionManager teardown 竞态
+            LogApplicationHelper::instance()->releaseConfigs();
             qApp->exit(0);
         } else {
             // 统计所有崩溃重复次数
@@ -1059,6 +1061,8 @@ void LogBackend::slot_coredumpFinished(int index)
                 Eventlogutils::GetInstance()->writeLogs(objCoredumpEvent);
                 LogApplicationHelper::instance()->saveLastRerportTime(latestCoredumpTime);
                 qCInfo(logBackend) << QString("Successfully reported %1 crash messages in total.").arg(afterCleanData.size());
+                // 先释放 DConfig/QGSettings 后台 dbus 子线程，避免 exit(0) 析构时与子线程 QDBusConnectionManager teardown 竞态
+                LogApplicationHelper::instance()->releaseConfigs();
                 qApp->exit(0);
             });
         }

--- a/application/utils.cpp
+++ b/application/utils.cpp
@@ -896,7 +896,15 @@ LoggerRules::LoggerRules(QObject *parent)
     : QObject(parent), m_rules(""), m_config(nullptr) {
 }
 
-LoggerRules::~LoggerRules() { m_config->deleteLater(); }
+LoggerRules::~LoggerRules()
+{
+    // 同步释放 DConfig，避免 deleteLater 在事件循环停止后不执行导致泄漏与后台 dbus 线程悬空。
+    // 仅当 QCoreApplication 仍存活时同步 delete（上报子进程路径满足；GUI 路径此时已析构，跳过以保持与原行为等价）。
+    if (m_config && QCoreApplication::instance()) {
+        delete m_config;
+        m_config = nullptr;
+    }
+}
 
 void LoggerRules::initLoggerRules()
 {


### PR DESCRIPTION
## 根因分析

崩溃进程为 `deepin-log-viewer --reportcoredump` 崩溃上报子进程（由 systemd `coredump-reporter.timer` 每 15 分钟以 root 触发），**非** `log-view-service` 服务进程。该子进程经 `LoggerRules`(`utils.cpp:910` DConfig 无 parent) + `LogApplicationHelper`(`logapplicationhelper.cpp:165` DConfig + `:205` QGSettings 无 parent) 创建 DConfig/QGSettings 共 4 个后台 dbus 子线程；`reportCoredumpInfo()` 完成后 `logbackend.cpp:991`/`:1062` 调 `qApp->exit(0)` 进入退出析构，与子线程 Qt `QDBusConnectionManager` teardown 竞态致崩。该缺陷在休眠唤醒压测下以低概率竞态形式出现（开发张廷安本地 1200+ 次仅复现 1 次）。根因复核已通过（结论级别：高置信假设）。

关键证据：
- `application/configs/coredump-reporter.timer:6-7` + `coredump-reporter.service:7`：每 15 分钟以 root 跑 `deepin-log-viewer --reportcoredump`，为崩溃子进程确定性触发源。
- `logapplicationhelper.cpp:165`(DConfig parent=this) + `:205`(QGSettings 无 parent) + `logapplicationhelper.h:39`(单例无 parent/无析构)：4 个 dbus 子线程生命周期失控。
- `logbackend.cpp:991`/`:1062` `qApp->exit(0)`：退出析构与子线程 teardown 竞态的直接触发点。

## 修复方案

防御性加固，确保进程退出前 DConfig/QGSettings 对象及后台 dbus 子线程生命周期受控、清理有序：
1. 为 `LogApplicationHelper` 的 QGSettings 补 parent(`this`)，修复泄漏、与同文件 DConfig 行为对齐。
2. 新增 `LogApplicationHelper::releaseConfigs()`，受护释放 DConfig/QGSettings 及其后台 dbus 子线程。
3. 在 `--reportcoredump` 退出点 `logbackend.cpp` 的 `qApp->exit(0)` 前调用 `releaseConfigs()`，使后台 dbus 子线程在 `QCoreApplication` 仍存活时被释放，避免与 `QDBusConnectionManager` 析构竞态。
4. `LoggerRules` 析构改为受护同步 `delete` DConfig（仅当 `QCoreApplication` 存活），避免 `deleteLater` 在事件循环停止后不执行导致泄漏与 dbus 线程悬空。

改动范围限定于已确认崩溃的 `--reportcoredump` 路径。`--export` CLI 路径（`logbackend.cpp:172`/`:1125`）存在同类潜在退出竞态，建议后续单独加固，不纳入本次 commit。

## 改动安全评估

低风险。未改任何 public 函数签名、未删除公开 API；`releaseConfigs()` 为新增 public 方法，调用点仅本次新增 2 处；`m_pGSettings`/`m_pDConfig` 其余访问点均已核查空安全，`releaseConfigs()` 调用位置保证其后不再访问这些对象。`~LoggerRules` 行为变化受 `QCoreApplication::instance()` 保护，正常路径与原行为等价（同步释放 vs 延迟释放），GUI 路径无回归。详见 `change-safety.md`。

PMS: BUG-301973

## Summary by Sourcery

Ensure DConfig and QGSettings background DBus threads are deterministically released before the coredump reporting process exits to avoid teardown races and crashes.

Bug Fixes:
- Prevent rare crashes in the coredump reporting subprocess caused by races between process exit and DBus connection teardown.

Enhancements:
- Add a controlled cleanup path in LogApplicationHelper to release DConfig/QGSettings and their background DBus threads before application exit.
- Make LoggerRules destructor synchronously delete its DConfig config object only while QCoreApplication is still alive to avoid leaks and dangling DBus threads.