### PR TITLE
fix: hoist pkexec auth out of per-file loop to prompt only once per load

### DIFF
--- a/application/logauththread.cpp
+++ b/application/logauththread.cpp
@@ -210,6 +210,33 @@ void LogAuthThread::run()
 void LogAuthThread::handleBoot()
 {
     QList<LOG_MSG_BOOT> bList;
+    // 鉴权上提：逐文件循环前只触发一次 pkexec，避免多轮转文件各自弹窗（Bug 371767）
+    if (!Utils::runInCmd) {
+        if (m_FilePath.isEmpty()) {
+            emit bootFinished(m_threadCount);
+            return;
+        }
+        initProccess();
+        m_process->setProcessChannelMode(QProcess::MergedChannels);
+        //共享内存对应变量置true，允许进程内部逻辑运行
+        ShareMemoryInfo shareInfo;
+        shareInfo.isStart = true;
+        SharedMemoryManager::instance()->setRunnableTag(shareInfo);
+        //启动日志需要提权获取，运行的时候把对应共享内存的名称传进去，方便获取进程拿标记量判断是否继续运行
+        m_process->start("pkexec", QStringList() << "logViewerAuth"
+                         << m_FilePath.at(0) << SharedMemoryManager::instance()->getRunnableKey());
+        m_process->waitForFinished(-1);
+        if (m_process->exitCode() != 0) {
+            emit bootFinished(m_threadCount);
+            return;
+        }
+        // 取消/失败时 polkit auth_admin_keep 缓存为空，非交互式校验确认未授权则不进入逐文件 DBus 读取（Bug 371767）
+        if (!Utils::checkAuthorizationCached("com.deepin.pkexec.logViewerAuth")) {
+            emit bootFinished(m_threadCount);
+            return;
+        }
+    }
+
     for (int i = 0; i < m_FilePath.count(); i++) {
         if (!m_FilePath.at(i).contains("txt")) {
             QFile file(m_FilePath.at(i)); // add by Airy
@@ -220,23 +247,6 @@ void LogAuthThread::handleBoot()
         }
         if (!m_canRun) {
             return;
-        }
-
-        if (!Utils::runInCmd) {
-            initProccess();
-            m_process->setProcessChannelMode(QProcess::MergedChannels);
-            //共享内存对应变量置true，允许进程内部逻辑运行
-            ShareMemoryInfo shareInfo;
-            shareInfo.isStart = true;
-            SharedMemoryManager::instance()->setRunnableTag(shareInfo);
-            //启动日志需要提权获取，运行的时候把对应共享内存的名称传进去，方便获取进程拿标记量判断是否继续运行
-            m_process->start("pkexec", QStringList() << "logViewerAuth"
-                             << m_FilePath.at(i) << SharedMemoryManager::instance()->getRunnableKey());
-            m_process->waitForFinished(-1);
-            if (m_process->exitCode() != 0) {
-                emit bootFinished(m_threadCount);
-                return;
-            }
         }
 
         QString byte = DLDBusHandler::instance(this)->readLog(m_FilePath.at(i));
@@ -292,6 +302,40 @@ void LogAuthThread::handleBoot()
 void LogAuthThread::handleKern()
 {
     QList<LOG_MSG_JOURNAL> kList;
+    // 鉴权上提：逐文件循环前只触发一次 pkexec，避免多轮转文件各自弹窗（Bug 371767）
+    if (!Utils::runInCmd) {
+        if (m_FilePath.isEmpty()) {
+            emit kernFinished(m_threadCount);
+            return;
+        }
+        initProccess();
+        if (!m_canRun) {
+            return;
+        }
+        m_process->setProcessChannelMode(QProcess::MergedChannels);
+        if (!m_canRun) {
+            return;
+        }
+        //共享内存对应变量置true，允许进程内部逻辑运行
+        ShareMemoryInfo shareInfo;
+        shareInfo.isStart = true;
+        SharedMemoryManager::instance()->setRunnableTag(shareInfo);
+        //启动日志需要提权获取，运行的时候把对应共享内存的名称传进去，方便获取进程拿标记量判断是否继续运行
+        m_process->start("pkexec", QStringList() << "logViewerAuth"
+                         << m_FilePath.at(0) << SharedMemoryManager::instance()->getRunnableKey());
+        m_process->waitForFinished(-1);
+        //有错则传出空数据（取消/失败只弹一次，不再进入循环）
+        if (m_process->exitCode() != 0) {
+            emit kernFinished(m_threadCount);
+            return;
+        }
+        // 取消/失败时 polkit auth_admin_keep 缓存为空，非交互式校验确认未授权则不进入逐文件 DBus 读取（Bug 371767）
+        if (!Utils::checkAuthorizationCached("com.deepin.pkexec.logViewerAuth")) {
+            emit kernFinished(m_threadCount);
+            return;
+        }
+    }
+
     for (int i = 0; i < m_FilePath.count(); i++) {
         if (!m_FilePath.at(i).contains("txt")) {
             QFile file(m_FilePath.at(i)); // add by Airy
@@ -300,34 +344,6 @@ void LogAuthThread::handleKern()
                 return;
             }
         }
-        if (!m_canRun) {
-            return;
-        }
-
-        if (!Utils::runInCmd) {
-            initProccess();
-            if (!m_canRun) {
-                return;
-            }
-            m_process->setProcessChannelMode(QProcess::MergedChannels);
-            if (!m_canRun) {
-                return;
-            }
-            //共享内存对应变量置true，允许进程内部逻辑运行
-            ShareMemoryInfo shareInfo;
-            shareInfo.isStart = true;
-            SharedMemoryManager::instance()->setRunnableTag(shareInfo);
-            //启动日志需要提权获取，运行的时候把对应共享内存的名称传进去，方便获取进程拿标记量判断是否继续运行
-            m_process->start("pkexec", QStringList() << "logViewerAuth"
-                             << m_FilePath.at(i) << SharedMemoryManager::instance()->getRunnableKey());
-            m_process->waitForFinished(-1);
-            //有错则传出空数据
-            if (m_process->exitCode() != 0) {
-                emit kernFinished(m_threadCount);
-                return;
-            }
-        }
-
         if (!m_canRun) {
             return;
         }
@@ -952,6 +968,54 @@ void LogAuthThread::handleDmesg()
 void LogAuthThread::handleAudit()
 {
     QList<LOG_MSG_AUDIT> aList;
+    // 鉴权上提：逐文件循环前只触发一次，避免审计多轮转文件各自弹窗（Bug 371767）
+    if (!Utils::runInCmd) {
+        if (m_FilePath.isEmpty()) {
+            emit auditFinished(m_threadCount);
+            return;
+        }
+        initProccess();
+        if (!m_canRun) {
+            return;
+        }
+        m_process->setProcessChannelMode(QProcess::MergedChannels);
+        if (!m_canRun) {
+            return;
+        }
+
+        if (DBusManager::isSEOpen()) {
+            if (DBusManager::isAuditAdmin()) {
+                // 是审计管理员，需要鉴权，有错则传出空数据
+                if (!Utils::checkAuthorization("com.deepin.pkexec.logViewerAuth.self", QCoreApplication::instance()->applicationPid())) {
+                    emit auditFinished(m_threadCount);
+                    return;
+                }
+            } else {
+                // 不是审计管理员，给出提示
+                emit auditFinished(m_threadCount, true);
+                return;
+            }
+        } else {
+            // 未开启等保四，鉴权逻辑同内核日志
+            ShareMemoryInfo shareInfo;
+            shareInfo.isStart = true;
+            SharedMemoryManager::instance()->setRunnableTag(shareInfo);
+            //启动日志需要提权获取，运行的时候把对应共享内存的名称传进去，方便获取进程拿标记量判断是否继续运行
+            m_process->start("pkexec", QStringList() << "logViewerAuth"
+                             << m_FilePath.at(0) << SharedMemoryManager::instance()->getRunnableKey());
+            m_process->waitForFinished(-1);
+            if (m_process->exitCode() != 0) {
+                emit auditFinished(m_threadCount);
+                return;
+            }
+            // 取消/失败时 polkit auth_admin_keep 缓存为空，非交互式校验确认未授权则不进入逐文件 DBus 读取（Bug 371767）
+            if (!Utils::checkAuthorizationCached("com.deepin.pkexec.logViewerAuth")) {
+                emit auditFinished(m_threadCount);
+                return;
+            }
+        }
+    }
+
     for (int i = 0; i < m_FilePath.count(); i++) {
         if (!m_FilePath.at(i).contains("txt")) {
             if (!DLDBusHandler::instance(this)->isFileExist(m_FilePath.at(i))) {
@@ -959,48 +1023,6 @@ void LogAuthThread::handleAudit()
                 return;
             }
         }
-        if (!m_canRun) {
-            return;
-        }
-
-        if (!Utils::runInCmd) {
-            initProccess();
-            if (!m_canRun) {
-                return;
-            }
-            m_process->setProcessChannelMode(QProcess::MergedChannels);
-            if (!m_canRun) {
-                return;
-            }
-
-            if (DBusManager::isSEOpen()) {
-                if (DBusManager::isAuditAdmin()) {
-                    // 是审计管理员，需要鉴权，有错则传出空数据
-                    if (!Utils::checkAuthorization("com.deepin.pkexec.logViewerAuth.self", QCoreApplication::instance()->applicationPid())) {
-                        emit auditFinished(m_threadCount);
-                        return;
-                    }
-                } else {
-                    // 不是审计管理员，给出提示
-                    emit auditFinished(m_threadCount, true);
-                    return;
-                }
-            } else {
-                // 未开启等保四，鉴权逻辑同内核日志
-                ShareMemoryInfo shareInfo;
-                shareInfo.isStart = true;
-                SharedMemoryManager::instance()->setRunnableTag(shareInfo);
-                //启动日志需要提权获取，运行的时候把对应共享内存的名称传进去，方便获取进程拿标记量判断是否继续运行
-                m_process->start("pkexec", QStringList() << "logViewerAuth"
-                                 << m_FilePath.at(i) << SharedMemoryManager::instance()->getRunnableKey());
-                m_process->waitForFinished(-1);
-                if (m_process->exitCode() != 0) {
-                    emit auditFinished(m_threadCount);
-                    return;
-                }
-            }
-        }
-
         if (!m_canRun) {
             return;
         }

--- a/application/parsethread/parsethreadkern.cpp
+++ b/application/parsethread/parsethreadkern.cpp
@@ -52,6 +52,42 @@ void ParseThreadKern::handleKern()
     QList<QString> dataList;
     qint64 gStartLine = m_filter.segementIndex * SEGEMENT_SIZE;
     m_FilePath = DLDBusHandler::instance(this)->getFileInfo(m_filter.filePath, false);
+
+    // 鉴权上提：在逐文件循环前只触发一次 pkexec 鉴权，避免内核多轮转文件各自弹窗（Bug 371767）
+    // 成功后 polkit auth_admin_keep 缓存命中，循环内各文件经 DBus 读取时不再重复鉴权
+    if (!Utils::runInCmd) {
+        if (m_FilePath.isEmpty()) {
+            emit parseFinished(m_threadCount, m_type);
+            return;
+        }
+        initProccess();
+        if (!m_canRun) {
+            return;
+        }
+        m_process->setProcessChannelMode(QProcess::MergedChannels);
+        if (!m_canRun) {
+            return;
+        }
+        //共享内存对应变量置true，允许进程内部逻辑运行
+        ShareMemoryInfo shareInfo;
+        shareInfo.isStart = true;
+        SharedMemoryManager::instance()->setRunnableTag(shareInfo);
+        //启动日志需要提权获取，运行的时候把对应共享内存的名称传进去，方便获取进程拿标记量判断是否继续运行
+        m_process->start("pkexec", QStringList() << "logViewerAuth"
+                         << m_FilePath.at(0) << SharedMemoryManager::instance()->getRunnableKey());
+        m_process->waitForFinished(-1);
+        //有错则传出空数据（取消/失败只弹一次，不再进入循环）
+        if (m_process->exitCode() != 0) {
+            emit parseFinished(m_threadCount, m_type, CancelAuth);
+            return;
+        }
+        // 取消/失败时 polkit auth_admin_keep 缓存为空，非交互式校验确认未授权则不进入逐文件 DBus 读取（Bug 371767）
+        if (!Utils::checkAuthorizationCached("com.deepin.pkexec.logViewerAuth")) {
+            emit parseFinished(m_threadCount, m_type, CancelAuth);
+            return;
+        }
+    }
+
     for (int i = 0; i < m_FilePath.count(); i++) {
         if (!m_FilePath.at(i).contains("txt")) {
             QFile file(m_FilePath.at(i)); // add by Airy
@@ -60,34 +96,6 @@ void ParseThreadKern::handleKern()
                 return;
             }
         }
-        if (!m_canRun) {
-            return;
-        }
-
-        if (!Utils::runInCmd) {
-            initProccess();
-            if (!m_canRun) {
-                return;
-            }
-            m_process->setProcessChannelMode(QProcess::MergedChannels);
-            if (!m_canRun) {
-                return;
-            }
-            //共享内存对应变量置true，允许进程内部逻辑运行
-            ShareMemoryInfo shareInfo;
-            shareInfo.isStart = true;
-            SharedMemoryManager::instance()->setRunnableTag(shareInfo);
-            //启动日志需要提权获取，运行的时候把对应共享内存的名称传进去，方便获取进程拿标记量判断是否继续运行
-            m_process->start("pkexec", QStringList() << "logViewerAuth"
-                             << m_FilePath.at(i) << SharedMemoryManager::instance()->getRunnableKey());
-            m_process->waitForFinished(-1);
-            //有错则传出空数据
-            if (m_process->exitCode() != 0) {
-                emit parseFinished(m_threadCount, m_type, CancelAuth);
-                return;
-            }
-        }
-
         if (!m_canRun) {
             return;
         }

--- a/application/utils.cpp
+++ b/application/utils.cpp
@@ -310,6 +310,17 @@ bool Utils::checkAuthorization(const QString &actionId, qint64 applicationPid)
     return result == Authority::Yes ? true : false;
 }
 
+bool Utils::checkAuthorizationCached(const QString &actionId)
+{
+    // 非交互式授权校验：Authority::None 不弹窗，仅查询 polkit 缓存。
+    // 取消/失败时 auth_admin_keep 缓存为空，返回 false；成功鉴权后缓存命中返回 true（Bug 371767）。
+    Authority::Result result;
+
+    result = Authority::instance()->checkAuthorizationSync(actionId, SystemBusNameSubject(QDBusConnection::systemBus().baseService()),
+                                                           Authority::None);
+    return result == Authority::Yes ? true : false;
+}
+
 QString Utils::osVersion()
 {
     QProcess *unlock = new QProcess;

--- a/application/utils.h
+++ b/application/utils.h
@@ -67,6 +67,8 @@ public:
     static QString mkMutiDir(const QString &path);
     //授权框
     static bool checkAuthorization(const QString &actionId, qint64 applicationPid);
+    // 非交互式授权校验：仅检查 polkit 缓存（不弹窗），用于取消/失败后判断是否已获授权（Bug 371767）
+    static bool checkAuthorizationCached(const QString &actionId);
     //系统版本号
     static QString osVersion();
     static QString auditType(const QString& eventType);


### PR DESCRIPTION
## 根因分析

查看内核日志时，鉴权窗口点击取消/X 后还会再弹一次；启动/xorg/崩溃日志只弹一次。

**活跃路径**为 `ParseThreadKern::handleKern()`（`application/parsethread/parsethreadkern.cpp`，分段解析），**非** `LogAuthThread::handleKern`（后者经 `git grep parseByKern` 核实无生产调用方，为 legacy 死代码）。该函数在逐轮转文件 `for` 循环内对每个文件都执行一次 `pkexec logViewerAuth`（`parsethreadkern.cpp:81-82`）。内核日志在 `/var/log` 下由 rsyslog/logrotate 轮转为多文件（`getFileInfo("kern")` 用 `nameFilter="kern.*"` 扫描，返回 `kern.log`/`kern.log.1`/…），故 pkexec 被调用 ≥2 次 → polkit 鉴权窗口 ≥2 次。

polkit 策略 `com.deepin.pkexec.logViewerAuth` = `auth_admin_keep`（`application/assets/com.deepin.pkexec.logViewerAuth.policy`）：**成功鉴权缓存复用、取消不缓存**。输入密码时首个 pkexec 成功 → keep 缓存 → 后续文件 pkexec 不再弹窗（只弹一次）；点击取消/X 时未产生缓存 → 循环继续到下一文件再次 pkexec → 「取消后还会再弹一次」。启动/xorg/崩溃日志在测试环境为单文件或非「逐文件 pkexec」结构，故只弹一次。

关键证据：
- `application/parsethread/parsethreadkern.cpp:55/81-82` — 逐文件循环 + 循环内逐文件 pkexec（活跃路径主因）。
- `application/assets/com.deepin.pkexec.logViewerAuth.policy` — `auth_admin_keep`（成功缓存、取消不缓存）。
- `logViewerService/logviewerservice.cpp:741/824` — `getFileInfo("kern")` 返回多个轮转文件。

历史：Bug 251521（`ca1fb9f`，CancelAuth 状态透传）、Bug 281209（`5759574`，xorg/dpkg/dnf 的 DBus 鉴权失败早退）均在基线内，但未把 pkexec 鉴权上提为「每次加载只触发一次」，内核多文件场景未覆盖。锁定基线：`release/eagle` HEAD `52b775169dd8e99ccc049eca7c5acf88b85411ad`。

## 修复方案

将「逐文件 `for` 循环内的 `pkexec` 鉴权」**上提到循环外，每次加载只触发一次**：循环前用 `m_FilePath.at(0)` 触发一次 `pkexec logViewerAuth`，成功后 polkit `auth_admin_keep` 缓存命中，循环内各文件经 DBus（`getLineCount`/`readLogLinesInRange`/`openLogStream`/`readLogInStream`，其 `checkAuth(s_Action_View)` 与 pkexec 共用同一 action 的 keep 缓存）读取时不再重复鉴权；鉴权失败/取消则 `emit` 对应 finished 信号（活跃路径 `ParseThreadKern::handleKern` 保持 `CancelAuth` 状态）并 return，只弹一次。上提后对 `m_FilePath` 空列表提前 `emit finished` 并 return，避免 `m_FilePath.at(0)` 越界，并与原空列表 Normal 结束语义一致。

**取消路径代码级保证（闭合 review 阻塞项）**：在 4 处上提点的 `pkexec` 之后，除既有 `exitCode()!=0` 守卫外，新增一次**非交互式**授权校验 `Utils::checkAuthorizationCached`（`PolkitQt1::Authority::None`，**不弹窗**，仅查询 `auth_admin_keep` 缓存）；取消/失败致缓存为空时立即 `emit` 对应 finished 信号并 `return`，**不进入**后续逐文件 DBus 读取循环。review 指出既有 `exitCode()!=0` 守卫在取消时不触发（取消时 `exitCode()` 为 0，逻辑证伪），仅靠该守卫不能阻止后续逐文件 `readLog`/`getLineCount` 等带 `checkAuth(AllowUserInteraction)` 的 DBus 调用再次弹窗；新增的非交互式校验以代码级保证「取消只弹一次」，不再依赖退出码或运行时假设。

同构同步处理同类隐患（活跃路径）：`LogAuthThread::handleBoot`（逐文件 pkexec）、`LogAuthThread::handleAudit`（SE 未开分支逐文件 pkexec + SE 开分支逐文件 `checkAuthorization`）一并上提；legacy 死代码 `LogAuthThread::handleKern` 同步同构上提。**不改** `handleDmesg`/`handleCoredump`：二者为单次 pkexec、无文件循环、且依赖 pkexec stdout 取数，不存在逐文件重复鉴权缺陷，改动会破坏取数路径。

## 改动安全评估

风险等级：**中风险（建议性继续）**。4 处函数签名均未改，finished 信号（`parseFinished`/`kernFinished`/`bootFinished`/`auditFinished`）及参数保持原样；调用方（`ParseThreadKern::run`/`LogAuthThread::run`，均为内部）不受影响。blame 显示目标块经 `ca1fb9f`（Bug 251521）引入 `CancelAuth` 状态——本修复保留该状态透传，不回滚 251521；`5759574`（Bug 281209）不在改动范围。DBus 取数路径完全不变；`logViewerAuth` helper 仍执行（仅由逐文件改为首文件一次），其 stdout 在 kern/boot/audit 路径本就未被消费（数据走 DBus）。行为变化即修复目标：多文件场景 pkexec 由 N 次降为 1 次，取消/失败时立即 finished 并 return（只弹一次）；单文件场景行为不变。
