### PR TITLE
fix: route journal app logs through root backend for privileged services

### DIFF
--- a/application/dbusproxy/dldbushandler.cpp
+++ b/application/dbusproxy/dldbushandler.cpp
@@ -116,6 +116,22 @@ QStringList DLDBusHandler::whiteListOutPaths()
 }
 
 /*!
+ * \~chinese \brief DLDBusHandler::getJournalLog 经 root 后端读取系统 journal
+ * \~chinese \param conditions JSON 串（含 name/filter/execPath）
+ * \~chinese \return journalctl -o json 的原始输出；DBus 调用失败时返回空串
+ */
+QString DLDBusHandler::getJournalLog(const QString &conditions)
+{
+    QDBusPendingReply<QString> reply = m_dbus->getJournalLog(conditions);
+    reply.waitForFinished();
+    if (reply.isError()) {
+        qCWarning(logDBusHandler) << "call dbus iterface 'getJournalLog()' failed. error info:" << reply.error().message();
+        return QString();
+    }
+    return reply.value();
+}
+
+/*!
  * \~chinese \brief DLDBusHandler::exitCode 返回进程状态
  * \~chinese \return 进程返回值
  */

--- a/application/dbusproxy/dldbushandler.h
+++ b/application/dbusproxy/dldbushandler.h
@@ -30,6 +30,7 @@ public:
     QString openLogStream(const QString &filePath);
     QString readLogInStream(const QString &token);
     QStringList whiteListOutPaths();
+    QString getJournalLog(const QString &conditions);
 
 private:
     explicit DLDBusHandler(QObject *parent = nullptr);

--- a/application/dbusproxy/dldbusinterface.h
+++ b/application/dbusproxy/dldbusinterface.h
@@ -157,6 +157,13 @@ public Q_SLOTS: // METHODS
         QList<QVariant> argumentList;
         return asyncCallWithArgumentList(QStringLiteral("whiteListOutPaths"), argumentList);
     }
+
+    inline QDBusPendingReply<QString> getJournalLog(const QString &conditions)
+    {
+        QList<QVariant> argumentList;
+        argumentList << QVariant::fromValue(conditions);
+        return asyncCallWithArgumentList(QStringLiteral("getJournalLog"), argumentList);
+    }
 Q_SIGNALS: // SIGNALS
 };
 

--- a/application/logapplicationparsethread.cpp
+++ b/application/logapplicationparsethread.cpp
@@ -9,11 +9,11 @@
 #include <DMessageBox>
 #include <DApplication>
 
-#include <systemd/sd-journal.h>
-
 #include <QDateTime>
 #include <QDebug>
 #include <QProcess>
+#include <QJsonDocument>
+#include <QJsonObject>
 
 #include <QLoggingCategory>
 
@@ -213,37 +213,26 @@ bool LogApplicationParseThread::parseByJournal(const APP_FILTERS &app_filter)
         return false;
     }
 
-    int r;
+    // journal 型应用日志由非特权前端 sd_journal_open 只能读到本进程可见的 journal 子集，
+    // 无法获取以 root/sudo 运行的服务（如 uos-service-support-agent）写入系统 journal 的日志。
+    // 改为经 root 后端 com.deepin.logviewer 以 journalctl 取数（-o json -r），前端按结构化
+    // 字段解析；过滤条件由后端安全构建参数列表（与 exportLog 一致，杜绝参数注入）。
+    QJsonObject conditionsObj;
+    conditionsObj["name"] = m_AppFiler.app;
+    conditionsObj["filter"] = m_AppFiler.filter;
+    conditionsObj["execPath"] = m_AppFiler.execPath;
+    const QString conditions = QString::fromUtf8(
+        QJsonDocument(conditionsObj).toJson(QJsonDocument::Compact));
 
-    sd_journal *j ;
+    const QString output = DLDBusHandler::instance(this)->getJournalLog(conditions);
     if ((!m_canRun)) {
         return false;
     }
-    //打开日志文件
-    r = sd_journal_open(&j, SD_JOURNAL_LOCAL_ONLY);
-    if ((!m_canRun)) {
-        sd_journal_close(j);
-        return false;
-    }
-    //r为系统借口返回值，小于0则表示失败，直接返回
-    if (r < 0) {
-        fprintf(stderr, "Failed to open journal: %s\n", strerror(-r));
-        return false;
-    }
-    //从尾部开始读，这样出来数据是倒叙，符合需求
-    sd_journal_seek_tail(j);
-    if ((!m_canRun)) {
-        sd_journal_close(j);
-        return false;
-    }
+    // 后端无有效匹配条件或鉴权失败时返回空，视作无日志
+    if (output.isEmpty())
+        return true;
 
-    // 增加日志等级筛选
-    if (m_AppFiler.lvlFilter != LVALL) {
-        QString prio = QString("PRIORITY=%1").arg(m_AppFiler.lvlFilter);
-        sd_journal_add_match(j, prio.toStdString().c_str(), 0);
-    }
-
-    // 查看是否开启通配符匹配
+    // 查看是否开启通配符匹配（journalctl 无法精确过滤通配符，前端按 CODE_CATEGORY 前缀过滤）
     bool bWildcardMatch = m_AppFiler.filter.endsWith("*");
     QString wildcard_CodeCategory = "";
     if (bWildcardMatch)
@@ -253,34 +242,6 @@ bool LogApplicationParseThread::parseByJournal(const APP_FILTERS &app_filter)
     if (wildcard_CodeCategory.isEmpty())
         bWildcardMatch = false;
 
-    bool bCanMatch = false;
-    // 增加日志exec筛选
-    if (!m_AppFiler.execPath.isEmpty()) {
-        sd_journal_add_match(j, QString("_EXE=%1").arg(m_AppFiler.execPath).toStdString().c_str(), 0);
-        bCanMatch = true;
-    }
-
-    // 增加code_category筛选，filter字段内容必须为完整的code_category种类名称
-    if (!m_AppFiler.filter.isEmpty() && m_AppFiler.filter != "*" && !bWildcardMatch) {
-        sd_journal_add_match(j, QString("CODE_CATEGORY=%1").arg(m_AppFiler.filter).toStdString().c_str(), 0);
-        bCanMatch = true;
-    }
-
-    // exec和filter都未配置，只能按进程名称进行筛选
-    if (!bCanMatch && !m_AppFiler.app.isEmpty()) {
-        sd_journal_add_match(j, QString("SYSLOG_IDENTIFIER=%1").arg(m_AppFiler.app).toStdString().c_str(), 0);
-        bCanMatch = true;
-    }
-
-    if ((!m_canRun)) {
-        sd_journal_close(j);
-        return false;
-    }
-
-    // journal不具备匹配条件，放弃journal应用日志解析
-    if (!bCanMatch)
-        return true;
-
     uint64_t beginTime = 0;
     uint64_t endTime = 0;
     if (m_AppFiler.timeFilterBegin != -1) {
@@ -289,61 +250,43 @@ bool LogApplicationParseThread::parseByJournal(const APP_FILTERS &app_filter)
     }
 
     int cnt = 0;
-    //调用宏开始迭代
-    SD_JOURNAL_FOREACH_BACKWARDS(j) {
+    // journalctl -r -o json 输出每行一个 JSON 对象，最新在前（与原 SD_JOURNAL_FOREACH_BACKWARDS 顺序一致）
+    const QStringList lines = output.split('\n', QString::SkipEmptyParts);
+    for (int i = 0; i < lines.size(); ++i) {
         if ((!m_canRun)) {
-            sd_journal_close(j);
             return false;
         }
-        const char *d;
-        size_t l;
+
+        const QJsonObject obj = QJsonDocument::fromJson(lines[i].toUtf8()).object();
+        if (obj.isEmpty())
+            continue;
+
+        // 获取时间：优先 _SOURCE_REALTIME_TIMESTAMP，回退 __REALTIME_TIMESTAMP（与原 sd_journal 行为一致）
+        const QString srcTs = obj.value("_SOURCE_REALTIME_TIMESTAMP").toString();
+        const QString recvTs = obj.value("__REALTIME_TIMESTAMP").toString();
+        if (srcTs.isEmpty() && recvTs.isEmpty())
+            continue;
 
         LOG_MSG_APPLICATOIN logMsg;
-        //获取时间
-        r = sd_journal_get_data(j, "_SOURCE_REALTIME_TIMESTAMP", reinterpret_cast<const void **>(&d), &l);
-        if (r < 0) {
-            r = sd_journal_get_data(j, "__REALTIME_TIMESTAMP", reinterpret_cast<const void **>(&d), &l);
-            if (r < 0) {
-                continue;
-            }
-        }
-
         logMsg.subModule = m_AppFiler.submodule;
-
-        uint64_t t;
-        sd_journal_get_realtime_usec(j, &t);
-        //解锁返回字符串长度上限，默认是64k，写0为无限
-        // sd_journal_set_data_threshold(j, 0);
-        QString dt = Utils::getReplaceColorStr(d).split("=").value(1);
+        // 显示时间优先 _SOURCE_REALTIME_TIMESTAMP，回退 __REALTIME_TIMESTAMP
+        logMsg.dateTime = getDateTimeFromStamp(srcTs.isEmpty() ? recvTs : srcTs);
+        // 过滤时间用 __REALTIME_TIMESTAMP（与原 sd_journal_get_realtime_usec 一致），缺失时回退 source
+        const uint64_t t = (recvTs.isEmpty() ? srcTs : recvTs).toULongLong();
         if (m_AppFiler.timeFilterBegin != -1) {
             if (t < beginTime || t > endTime)
                 continue;
         }
-        logMsg.dateTime = getDateTimeFromStamp(dt);
 
         // 根据filter进行通配符匹配查找
         if (bWildcardMatch) {
-            r = sd_journal_get_data(j, "CODE_CATEGORY", reinterpret_cast<const void **>(&d), &l);
-            QString code_category;
-            if (r >= 0) {
-                QStringList strList = Utils::getReplaceColorStr(d).split("=");
-                strList.removeFirst();
-                code_category = strList.join("=");
-                if (!code_category.startsWith(wildcard_CodeCategory))
-                    continue;
-            }
+            const QString code_category = obj.value("CODE_CATEGORY").toString();
+            if (!code_category.startsWith(wildcard_CodeCategory))
+                continue;
         }
 
         //获取信息体
-        r = sd_journal_get_data(j, "MESSAGE", reinterpret_cast<const void **>(&d), &l);
-        if (r < 0) {
-            logMsg.msg = "";
-        } else {
-            //出来的数据格式为 字段名= 信息体，但是因为信息体中也可能有=号，所以要把第一个去掉，后面的用=号拼起来
-            QStringList strList = Utils::getReplaceColorStr(d).split("=");
-            strList.removeFirst();
-            logMsg.msg = strList.join("=");
-        }
+        logMsg.msg = obj.value("MESSAGE").toString();
         logMsg.detailInfo = logMsg.msg;
 
         //如果日志太长就显示一部分
@@ -351,15 +294,18 @@ bool LogApplicationParseThread::parseByJournal(const APP_FILTERS &app_filter)
             logMsg.msg = logMsg.detailInfo.mid(0, 500);
         }
 
-        //获取等级
-        r = sd_journal_get_data(j, "PRIORITY", reinterpret_cast<const void **>(&d), &l);
-        if (r < 0) {
-            //有些时候的确会产生没有等级的日志，按照需求此时一律按调试处理，和journalctl 的筛选行为一致
-            logMsg.level = i2str(7);
-        } else {
-            //获取等级为字段名= 数字 ，数字为0-7 ，对应紧急到调试，需要转换
-            logMsg.level = i2str(Utils::getReplaceColorStr(d).split("=").value(1).toInt());
-        }
+        //获取等级：0-7 对应紧急到调试，与 journalctl 筛选行为一致；缺省按调试(7)处理
+        const QJsonValue prioVal = obj.value("PRIORITY");
+        int prio = 7;
+        if (!prioVal.isUndefined())
+            prio = prioVal.toString().toInt();
+        else if (m_AppFiler.lvlFilter != LVALL)
+            continue;  // 缺少 PRIORITY 的条目在原 journal PRIORITY= 匹配下会被排除
+        //日志等级筛选（原由 sd_journal_add_match PRIORITY= 在 journal 侧过滤，现前端过滤）
+        if (m_AppFiler.lvlFilter != LVALL && prio != m_AppFiler.lvlFilter)
+            continue;
+        logMsg.level = i2str(prio);
+
         cnt++;
         mutex.lock();
         m_appList.append(logMsg);
@@ -370,13 +316,9 @@ bool LogApplicationParseThread::parseByJournal(const APP_FILTERS &app_filter)
             mutex.lock();
             emit appData(m_threadCount, m_appList);
             m_appList.clear();
-            //sleep(100);
             mutex.unlock();
         }
     }
-
-    //第一次加载时这个之后的代码都不执行?故放到最后
-    sd_journal_close(j);
 
     return true;
 }

--- a/logViewerService/assets/data/com.deepin.logviewer.xml
+++ b/logViewerService/assets/data/com.deepin.logviewer.xml
@@ -58,5 +58,9 @@
     <method name="whiteListOutPaths">
       <arg type="as" direction="out"/>
     </method>
+    <method name="getJournalLog">
+      <arg type="s" direction="out"/>
+      <arg name="conditions" type="s" direction="in"/>
+    </method>
   </interface>
 </node>

--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -1039,6 +1039,60 @@ bool LogViewerService::exportLog(const QString &outDir, const QString &in, bool 
     return true;
 }
 
+/*!
+ * \~chinese \brief LogViewerService::getJournalLog 通过 root 后端读取系统 journal
+ * \~chinese \param conditions JSON 串，含 name/filter/execPath，用于安全构造 journalctl 过滤条件
+ * \~chinese \return journalctl `-o json -r --no-pager` 的原始输出（每行一个 JSON 对象）；鉴权失败或无有效匹配条件时返回空串
+ *
+ * 前端「应用日志」journal 型子模块在非特权进程内 sd_journal_open 只能读到本进程可见的
+ * journal 子集，无法获取以 root/sudo 运行的服务（如 uos-service-support-agent）写入
+ * 系统 journal 的日志，故经此后端以 root 执行 journalctl 取数。过滤条件构造复用
+ * exportLog 已验证的安全模式：直接构建 journalctl 参数列表，不进行字符串拼接，
+ * 杜绝参数注入；无输出路径，无路径穿越风险。
+ */
+QString LogViewerService::getJournalLog(const QString &conditions)
+{
+    if (!checkAuth(s_Action_View))
+        return QString();
+
+    QJsonParseError parseError;
+    QJsonDocument document = QJsonDocument::fromJson(conditions.toUtf8(), &parseError);
+    if (parseError.error != QJsonParseError::NoError || !document.isObject())
+        return QString();
+
+    QJsonObject object = document.object();
+    const QString submoduleName = object.value("name").toString();
+    const QString filter = object.value("filter").toString();
+    const QString execPath = object.value("execPath").toString();
+
+    // 直接构建 journalctl 参数列表，杜绝字符串拼接的参数注入风险（与 exportLog 一致）
+    QStringList args;
+    bool bCanMatch = false;
+    if (!execPath.isEmpty()) {
+        args << QString("_EXE=%1").arg(execPath);
+        bCanMatch = true;
+    }
+    // 通配符匹配（filter 以 * 结尾）无法用 journalctl 精确过滤，留给前端按 CODE_CATEGORY 前缀过滤
+    if (!filter.isEmpty() && filter != "*" && !filter.endsWith("*")) {
+        args << QString("CODE_CATEGORY=%1").arg(filter);
+        bCanMatch = true;
+    }
+    if (!bCanMatch && !submoduleName.isEmpty()) {
+        args << QString("SYSLOG_IDENTIFIER=%1").arg(submoduleName);
+        bCanMatch = true;
+    }
+
+    // 不具备匹配条件，返回空
+    if (!bCanMatch)
+        return QString();
+
+    // -r 倒序（最新优先，与前端原 SD_JOURNAL_FOREACH_BACKWARDS 行为一致）；
+    // -o json 每行一个 JSON 对象，保留结构化字段供前端解析；--no-pager 禁用分页避免阻塞
+    args << "-o" << "json" << "-r" << "--no-pager";
+
+    return QString::fromUtf8(processCmdWithArgs("journalctl", args));
+}
+
 bool LogViewerService::exportOpsLog(const QDBusUnixFileDescriptor &fd)
 {
     if(!checkAuth(s_Action_View)) { //非法调用

--- a/logViewerService/logviewerservice.h
+++ b/logViewerService/logviewerservice.h
@@ -48,6 +48,9 @@ public Q_SLOTS:
     // 仅能执行特定合法命令
     Q_SCRIPTABLE QString executeCmd(const QString &cmd);
     Q_SCRIPTABLE QStringList whiteListOutPaths();
+    // 经 root 后端读取系统 journal，供非特权前端获取 journal 型应用日志。
+    // conditions 为 JSON 串（含 name/filter/execPath），后端据此安全构造 journalctl 过滤参数。
+    Q_SCRIPTABLE QString getJournalLog(const QString &conditions);
 
 public:
     // 获取用户家目录


### PR DESCRIPTION
# fix: route journal app logs through root backend for privileged services

**PMS**: [BUG-264737](https://pms.uniontech.com/bug-view-264737.html)
**Branch**: `release/eagle` (baseline `52b7751`)

## 问题现象

在「日志收集工具 → 应用日志 → 服务支持」选择 `uos-service-support-agent` 等以 sudo/root 运行的服务子模块时，界面无日志输出；但命令行用 `journalctl`（以 root / adm / systemd-journal 权限）可正常输出该 agent 日志。

## 根因

`uos-service-support-agent` 以 sudo/root 运行，其日志写入**系统 journal**。而 deepin-log-viewer 的「应用日志」**实时查看**路径（`logType=="journal"`）在**非特权 GUI 进程**内直接 `sd_journal_open(SD_JOURNAL_LOCAL_ONLY)` 读取 journal（`application/logapplicationparsethread.cpp` 旧 `parseByJournal`），未经过 root 后端 `com.deepin.logviewer`。非 root 且不属于 `adm`/`systemd-journal` 组的进程读不到其他用户（root）产生的系统 journal 条目 → 迭代为空 → 界面无日志。

- 实时查看（缺陷点）：`application/logapplicationparsethread.cpp` 旧 `parseByJournal`（`sd_journal_open` 非特权直读）。
- 导出路径（**不受影响**，非缺陷点）：`logViewerService/logviewerservice.cpp` `exportLog` 在 root 后端执行 `journalctl`，可读系统 journal。

## 修复方案

将 journal 型实时查看改为经 root 后端取数（与历史备注及 gerrit 243958 方向一致）：

1. **后端新增** `Q_SCRIPTABLE QString LogViewerService::getJournalLog(const QString &conditions)`：以 root 执行 `journalctl -o json -r --no-pager`，按 `_EXE=`/`CODE_CATEGORY=`/`SYSLOG_IDENTIFIER=` 过滤。过滤条件复用 `exportLog` 已验证的**参数列表安全构造**（`QStringList` 传给 `QProcess`，无 shell、无字符串拼接，杜绝参数注入，与 `8c0400e` 安全加固一致）；`checkAuth(s_Action_View)` polkit 鉴权（`auth_admin_keep`）；无文件输出 → 无路径穿越/暴露面。
2. **前端 `parseByJournal` 重写**：构造 `conditions` JSON（`name`/`filter`/`execPath`）调用后端，解析 `journalctl -o json` 每行一个 JSON 对象，按结构化字段（`_SOURCE_REALTIME_TIMESTAMP`/`__REALTIME_TIMESTAMP`/`MESSAGE`/`PRIORITY`/`CODE_CATEGORY`）构建 `LOG_MSG_APPLICATOIN`。移除非特权 `sd_journal_open` 直读。
3. **DBus 接线**：补齐 introspection XML（`com.deepin.logviewer.xml`）、前端代理（`dldbusinterface.h`）、封装（`dldbushandler.h/.cpp`，同步 `waitForFinished` + 错误检测）。

## 行为保真

- 顺序：`journalctl -r`（最新在前）与原 `SD_JOURNAL_FOREACH_BACKWARDS` 一致。
- 时间过滤：显示用 `_SOURCE_REALTIME_TIMESTAMP`（优先）/`__REALTIME_TIMESTAMP`，过滤用 `__REALTIME_TIMESTAMP`，与原 `sd_journal_get_realtime_usec` 一致。
- 等级过滤：原 `sd_journal_add_match(PRIORITY=N)` 服务端过滤 → 前端 `prio != lvlFilter` 过滤；无 `PRIORITY` 条目在 `lvlFilter != LVALL` 时排除（与原 journal match 一致），`LVALL` 时按 Debug(7) 显示。
- `CODE_CATEGORY` 通配符：保留前端 `startsWith` 前缀过滤（journalctl 无法精确匹配通配符）。
- 500 条批量 `emit appData`、500 字截断、`subModule` 赋值均保留。

## 改动安全评估

- **风险等级：低**。无函数签名变更、无公开 API 删除；`parseByJournal` 唯一调用者 `doWork()` 不受影响；`getJournalLog` 为新增方法。
- 保留近期修复：`0e1bd43`（D-Bus 鉴权失败 + mutex UB）—— 早返回路径均无 `mutex.unlock()`；`8c0400e`（命令注入加固）—— 复用其 arg-list 构造。
- 既有 file 型应用日志、导出路径行为不变。

## 测试建议

- 选 `uos-service-support-agent`（root 服务）子模块，确认界面能显示其日志（需先触发授权诊断产生日志）。
- 选普通用户级应用（非 root）journal 子模块，确认日志仍正常显示（回归）。
- 等级/时间段/关键词筛选、通配符 `CODE_CATEGORY` 子模块仍生效。
- 导出应用日志路径未改动，回归导出 `uos-service-support-agent` 日志。

## Summary by Sourcery

Route journal-based application log viewing through the root backend so non-privileged GUI processes can display logs from privileged services.

Bug Fixes:
- Ensure journal application logs from root/sudo-run services are accessible in the GUI by fetching them via a privileged backend service instead of direct sd_journal access.

Enhancements:
- Add a root backend DBus method that safely wraps journalctl with structured filtering and JSON output for journal application logs.
- Update the frontend journal parsing logic to consume JSON output from the backend, preserving existing time, level, and wildcard CODE_CATEGORY filtering semantics.