### PR TITLE
fix(dbus): reimplement DLDBusHandler as a standard thread-safe singleton

### DIFF
--- a/application/dbusproxy/dldbushandler.cpp
+++ b/application/dbusproxy/dldbushandler.cpp
@@ -9,16 +9,13 @@
 
 Q_DECLARE_LOGGING_CATEGORY(logApp)
 
-DLDBusHandler *DLDBusHandler::m_statichandeler = nullptr;
-
-DLDBusHandler *DLDBusHandler::instance(QObject *parent)
+// 标准的 Meyers 单例：利用 C++11 魔法静态变量（函数局部静态对象），
+// 其初始化由编译器保证线程安全且仅执行一次，多线程首次调用即创建。
+// 单例无父对象，自行管理生命周期，进程退出时由 OS 回收。
+DLDBusHandler *DLDBusHandler::instance()
 {
-    // qCDebug(logApp) << "DLDBusHandler::instance called with parent:" << parent;
-    if (parent != nullptr && m_statichandeler == nullptr) {
-        qCDebug(logApp) << "Creating new DLDBusHandler instance";
-        m_statichandeler = new DLDBusHandler(parent);
-    }
-    return m_statichandeler;
+    static DLDBusHandler instance;
+    return &instance;
 }
 
 DLDBusHandler::~DLDBusHandler()
@@ -31,6 +28,7 @@ DLDBusHandler::DLDBusHandler(QObject *parent)
     : QObject(parent)
 {
     qCDebug(logApp) << "DLDBusHandler constructor called with parent:" << parent;
+    // 注意：D-Bus 接口对象以 this 为父对象，随单例一起销毁。
     m_dbus = new DeepinLogviewerInterface("com.deepin.logviewer",
                                           "/com/deepin/logviewer",
                                           QDBusConnection::systemBus(),

--- a/application/dbusproxy/dldbushandler.h
+++ b/application/dbusproxy/dldbushandler.h
@@ -12,7 +12,14 @@ class DLDBusHandler : public QObject
 {
     Q_OBJECT
 public:
-    static DLDBusHandler *instance(QObject *parent = nullptr);
+    /**
+     * @brief 获取单例对象。线程安全（C++11 魔法静态变量保证）。
+     * @note 旧实现要求 parent 非空才会创建实例，导致在子线程中首次调用
+     *       （如不传 this 的 DLDBusHandler::instance()->executeCmd(...)）
+     *       会返回 nullptr，从而引发空指针崩溃。现改为标准的 Meyers 单例，
+     *       移除 parent 参数，单例自行管理生命周期，多线程下首次调用即创建。
+     */
+    static DLDBusHandler *instance();
     ~DLDBusHandler();
     QString readLog(const QString &filePath);
     QStringList readLogLinesInRange(const QString &filePath, qint64 startLine = 0, qint64 lineCount = 500, bool bReverse = true);
@@ -39,7 +46,6 @@ private:
     void releaseFilePathCacheFile(const QString &cacheFilePath);
 
 private:
-    static DLDBusHandler *m_statichandeler;
     DeepinLogviewerInterface *m_dbus;
     QStringList filePath;
     bool m_bGetFileInfoError = false;

--- a/application/displaycontent.cpp
+++ b/application/displaycontent.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -3878,7 +3878,7 @@ void DisplayContent::generateAuditFile(int id, int lId, const QString &iSearchSt
     Q_UNUSED(iSearchStr);
 
     // 若审计日志不存在，则显示审计日志不存在
-    if (!DLDBusHandler::instance(this)->isFileExist(AUDIT_TREE_DATA)) {
+    if (!DLDBusHandler::instance()->isFileExist(AUDIT_TREE_DATA)) {
         setLoadState(DATA_NO_AUDIT_LOG);
         m_detailWgt->cleanText();
         m_detailWgt->hideLine(true);

--- a/application/logallexportthread.cpp
+++ b/application/logallexportthread.cpp
@@ -59,7 +59,7 @@ bool LogAllExportThread::addFileToZip(const QString &filePath, const QString &zi
         qCDebug(logApp) << "Direct file access failed, trying DBus export for:" << filePath;
 
         // For permission-restricted files like auth.log, use DBus exportLog interface
-        if (DLDBusHandler::instance(nullptr)->exportLog(QFileInfo(m_outfile).path(), filePath, true)) {
+        if (DLDBusHandler::instance()->exportLog(QFileInfo(m_outfile).path(), filePath, true)) {
             // Read the exported content and add to zip
             QFile exportedFile(QFileInfo(m_outfile).path() + "/" + QFileInfo(filePath).fileName());
             if (exportedFile.open(QIODevice::ReadOnly)) {
@@ -277,19 +277,19 @@ void LogAllExportThread::run()
             data.commands.push_back("last");
         } else if (it.contains(DPKG_TREE_DATA, Qt::CaseInsensitive)) {
             data.logCategory = "dpkg";
-            data.files.append(DLDBusHandler::instance(nullptr)->getFileInfo("dpkg", false));
+            data.files.append(DLDBusHandler::instance()->getFileInfo("dpkg", false));
         } else if (it.contains(KERN_TREE_DATA, Qt::CaseInsensitive)) {
             data.logCategory = "kernel";
-            data.files.append(DLDBusHandler::instance(nullptr)->getFileInfo("kern", false));
+            data.files.append(DLDBusHandler::instance()->getFileInfo("kern", false));
         } else if (it.contains(XORG_TREE_DATA, Qt::CaseInsensitive)) {
             data.logCategory = "xorg";
-            data.files.append(DLDBusHandler::instance(nullptr)->getFileInfo("Xorg", false));
+            data.files.append(DLDBusHandler::instance()->getFileInfo("Xorg", false));
         } else if (it.contains(DNF_TREE_DATA, Qt::CaseInsensitive)) {
             data.logCategory = "dnf";
-            data.files.append(DLDBusHandler::instance(nullptr)->getFileInfo("dnf", false));
+            data.files.append(DLDBusHandler::instance()->getFileInfo("dnf", false));
         } else if (it.contains(BOOT_TREE_DATA, Qt::CaseInsensitive)) {
             data.logCategory = "boot";
-            data.files.append(DLDBusHandler::instance(nullptr)->getFileInfo("boot", false));
+            data.files.append(DLDBusHandler::instance()->getFileInfo("boot", false));
         } else if (it.contains(KWIN_TREE_DATA, Qt::CaseInsensitive)) {
             data.logCategory = "kwin";
             data.files.append(KWIN_TREE_DATA);
@@ -308,7 +308,7 @@ void LogAllExportThread::run()
                     if (appLogConfig.subModules.size() == 1 &&  submodule.name == appLogConfig.name)
                         subDir = dir;
                     if (submodule.logType == "file") {
-                        QStringList logPaths = DLDBusHandler::instance(nullptr)->getFileInfo(submodule.logPath);
+                        QStringList logPaths = DLDBusHandler::instance()->getFileInfo(submodule.logPath);
                         logPaths.removeDuplicates();
                         if (logPaths.size() > 0) {
                             data.dir2Files[subDir] = logPaths;
@@ -327,12 +327,12 @@ void LogAllExportThread::run()
             }
         } else if (it.contains(COREDUMP_TREE_DATA, Qt::CaseInsensitive)) {
             data.logCategory = "coredump";
-            data.files.append(DLDBusHandler::instance(nullptr)->getFileInfo("coredump", false));
+            data.files.append(DLDBusHandler::instance()->getFileInfo("coredump", false));
         } else if (it.contains(OTHER_TREE_DATA, Qt::CaseInsensitive)) {
             data.logCategory = "others";
             auto otherLogListPair = LogApplicationHelper::instance()->getOtherLogList();
             for (auto &it2 : otherLogListPair) {
-                QStringList paths = DLDBusHandler::instance(nullptr)->getOtherFileInfo(it2.at(1));
+                QStringList paths = DLDBusHandler::instance()->getOtherFileInfo(it2.at(1));
                 paths.removeDuplicates();
                 if (paths.size() > 1)
                     data.dir2Files[it2.at(0)] = paths;
@@ -347,7 +347,7 @@ void LogAllExportThread::run()
             }
         } else if (it.contains(AUDIT_TREE_DATA, Qt::CaseInsensitive)) {
             data.logCategory = "audit";
-            data.files.append(DLDBusHandler::instance(nullptr)->getFileInfo("audit", false));
+            data.files.append(DLDBusHandler::instance()->getFileInfo("audit", false));
         } else if (it.contains(AUTH_TREE_DATA, Qt::CaseInsensitive)) {
             data.logCategory = "auth";
             QStringList authLogFiles = LogApplicationHelper::instance()->getAuthLogList();
@@ -486,7 +486,7 @@ void LogAllExportThread::run()
         // root 服务在 /var/log 下创建随机临时目录收集日志，整体压缩后写入该 fd，并自行清理临时目录。
         // 前端拿到写入完成的压缩包后，解压到 opsLogPath，再删除该压缩包。
         QString opsZipPath = tmpOpsDirPath + "/" + "log-ops.zip";
-        bool opsOk = DLDBusHandler::instance(this)->exportOpsLog(opsZipPath);
+        bool opsOk = DLDBusHandler::instance()->exportOpsLog(opsZipPath);
         if (!opsOk || !QFileInfo(opsZipPath).exists()) {
             qCCritical(logApp) << "exportOpsLog failed or zip not produced";
             zipClose(m_zipFile, nullptr);

--- a/application/logapplicationparsethread.cpp
+++ b/application/logapplicationparsethread.cpp
@@ -148,9 +148,9 @@ bool LogApplicationParseThread::parseByFile(const APP_FILTERS &app_filter)
         qCWarning(logApp) << "Empty path for submodule:" << app_filter.submodule;
         emit appFinished(m_threadCount);
     } else {
-        QStringList filePath = DLDBusHandler::instance(this)->getFileInfo(m_AppFiler.path);
+        QStringList filePath = DLDBusHandler::instance()->getFileInfo(m_AppFiler.path);
         // 如果getFileInfo的dbus调用失败(如用户取消授权)，直接返回false以中止后续子模块处理
-        if (DLDBusHandler::instance(this)->isGetFileInfoError()) {
+        if (DLDBusHandler::instance()->isGetFileInfoError()) {
             qCWarning(logApp) << "D-Bus getFileInfo failed (authorization canceled) for submodule:"
                             << app_filter.submodule << ", aborting remaining submodules";
             emit appFinished(m_threadCount);
@@ -161,7 +161,7 @@ bool LogApplicationParseThread::parseByFile(const APP_FILTERS &app_filter)
                 return false;
             }
             //按行解析
-            QByteArray outByte = DLDBusHandler::instance(this)->readLog(filePath[i]).toUtf8();
+            QByteArray outByte = DLDBusHandler::instance()->readLog(filePath[i]).toUtf8();
             // dbus鉴权失败，不再继续解析
             if (outByte.endsWith("is not allowed to configrate firewall. checkAuthorization failed.")) {
                 qCWarning(logApp) << "D-Bus authorization failed for file:" << filePath[i];

--- a/application/logauththread.cpp
+++ b/application/logauththread.cpp
@@ -277,7 +277,7 @@ void LogAuthThread::handleBoot()
             }
         }
 
-        QString byte = DLDBusHandler::instance(this)->readLog(m_FilePath.at(i));
+        QString byte = DLDBusHandler::instance()->readLog(m_FilePath.at(i));
         byte.replace('\u0000', "").replace("\x01", "");
         QStringList strList = byte.split('\n', SKIP_EMPTY_PARTS);
 
@@ -378,7 +378,7 @@ void LogAuthThread::handleKern()
         //如果是压缩文件，对其解压缩
         QString filePath = m_FilePath.at(i);
         if(QString::compare(QFileInfo(filePath).suffix(), "gz", Qt::CaseInsensitive) == 0){
-            QStringList filePathList = DLDBusHandler::instance(this)->getFileInfo(filePath);
+            QStringList filePathList = DLDBusHandler::instance()->getFileInfo(filePath);
             if(filePathList.size()){
                 filePath = filePathList.at(0);
             }else {
@@ -386,10 +386,10 @@ void LogAuthThread::handleKern()
             }
         }
 
-        auto token = DLDBusHandler::instance(this)->openLogStream(filePath);
+        auto token = DLDBusHandler::instance()->openLogStream(filePath);
         QString byte;
         while(1) {
-            auto temp = DLDBusHandler::instance(this)->readLogInStream(token);
+            auto temp = DLDBusHandler::instance()->readLogInStream(token);
 
             if(temp.isEmpty()) {
                 break;
@@ -585,7 +585,7 @@ void LogAuthThread::handleXorg()
             return;
         }
         qCDebug(logApp) << "Processing Xorg file:" << m_FilePath.at(i);
-        QString m_Log = DLDBusHandler::instance(this)->readLog(m_FilePath.at(i));
+        QString m_Log = DLDBusHandler::instance()->readLog(m_FilePath.at(i));
         // dbus鉴权失败，不再继续解析
         if (m_Log.endsWith("is not allowed to configrate firewall. checkAuthorization failed.")) {
             qCDebug(logApp) << "Xorg log file is not allowed to configrate firewall";
@@ -663,7 +663,7 @@ void LogAuthThread::handleDkpg()
         }
         qCDebug(logApp) << "Processing DPKG file:" << m_FilePath.at(i);
 
-        QString m_Log = DLDBusHandler::instance(this)->readLog(m_FilePath.at(i));
+        QString m_Log = DLDBusHandler::instance()->readLog(m_FilePath.at(i));
         // dbus鉴权失败，不再继续解析
         if (m_Log.endsWith("is not allowed to configrate firewall. checkAuthorization failed.")) {
             emit dpkgFinished(m_threadCount);
@@ -896,7 +896,7 @@ void LogAuthThread::handleDnf()
             return;
         }
         qCDebug(logApp) << "Processing DNF file:" << m_FilePath.at(i);
-        QByteArray outByte = DLDBusHandler::instance(this)->readLog(m_FilePath.at(i)).toUtf8();
+        QByteArray outByte = DLDBusHandler::instance()->readLog(m_FilePath.at(i)).toUtf8();
         // dbus鉴权失败，不再继续解析
         if (outByte.endsWith("is not allowed to configrate firewall. checkAuthorization failed.")) {
             qCDebug(logApp) << "DNF log file is not allowed to configrate firewall";
@@ -1072,7 +1072,7 @@ void LogAuthThread::handleAudit()
     QList<LOG_MSG_AUDIT> aList;
     for (int i = 0; i < m_FilePath.count(); i++) {
         if (!m_FilePath.at(i).contains("txt")) {
-            if (!DLDBusHandler::instance(this)->isFileExist(m_FilePath.at(i))) {
+            if (!DLDBusHandler::instance()->isFileExist(m_FilePath.at(i))) {
                 qCDebug(logApp) << "Audit log file does not exist:" << m_FilePath.at(i);
                 emit auditFinished(m_threadCount);
                 return;
@@ -1132,11 +1132,11 @@ void LogAuthThread::handleAudit()
         }
 
         QString byte;
-        if (Utils::convertToMB(DLDBusHandler::instance(this)->getFileSize(m_FilePath.at(i))) > DBUS_THRESHOLD_MAX) {
+        if (Utils::convertToMB(DLDBusHandler::instance()->getFileSize(m_FilePath.at(i))) > DBUS_THRESHOLD_MAX) {
             // 日志文件超过100MB，使用文本流读取日志数据，避免DBUS接口被数据流量撑爆
-            auto token = DLDBusHandler::instance(this)->openLogStream(m_FilePath.at(i));
+            auto token = DLDBusHandler::instance()->openLogStream(m_FilePath.at(i));
             while(1) {
-                auto temp = DLDBusHandler::instance(this)->readLogInStream(token);
+                auto temp = DLDBusHandler::instance()->readLogInStream(token);
 
                 if(temp.isEmpty()) {
                     break;
@@ -1145,7 +1145,7 @@ void LogAuthThread::handleAudit()
                 byte += temp;
             }
         } else {
-            byte = DLDBusHandler::instance(this)->readLog(m_FilePath.at(i));
+            byte = DLDBusHandler::instance()->readLog(m_FilePath.at(i));
         }
 
         byte.replace('\u0000', "").replace("\x01", "");
@@ -1369,7 +1369,7 @@ void LogAuthThread::handleAuth()
         }
         
         // Read file content using DBus
-        QString m_Log = DLDBusHandler::instance(this)->readLog(filePath);
+        QString m_Log = DLDBusHandler::instance()->readLog(filePath);
         
         // Check for DBus authentication failure
         if (m_Log.endsWith("is not allowed to configrate firewall. checkAuthorization failed.")) {

--- a/application/logbackend.cpp
+++ b/application/logbackend.cpp
@@ -387,7 +387,7 @@ int LogBackend::exportTypeLogs(const QString &outDir, const QString &type)
 
         auto otherLogListPair = LogApplicationHelper::instance()->getOtherLogList();
         for (auto &it2 : otherLogListPair) {
-            QStringList logPaths = DLDBusHandler::instance(nullptr)->getOtherFileInfo(it2.at(1));
+            QStringList logPaths = DLDBusHandler::instance()->getOtherFileInfo(it2.at(1));
             logPaths.removeDuplicates();
             if (logPaths.size() > 1) {
                 QString tmpSubCategoryOutPath = QString("%1/%2/").arg(categoryOutPath).arg(it2.at(0));
@@ -528,7 +528,7 @@ int LogBackend::exportAppLogs(const QString &outDir, const QString &appName)
         if (appLogConfig.subModules.size() == 1 &&  submodule.name == appLogConfig.name)
             subCategoryOutPath = categoryOutPath;
         if (submodule.logType == "file") {
-            QStringList logPaths = DLDBusHandler::instance(nullptr)->getFileInfo(submodule.logPath);
+            QStringList logPaths = DLDBusHandler::instance()->getFileInfo(submodule.logPath);
             logPaths.removeDuplicates();
             if (logPaths.size() > 0) {
                 resetCategoryOutputPath(subCategoryOutPath);
@@ -2434,13 +2434,13 @@ int LogBackend::getNextSegementIndex(LOG_FLAG type, bool bNext/* = true*/)
     qint64 totalLineCount = 0;
     int nSegementIndex = -1;
     if (type == KERN) {
-        QStringList filePaths = DLDBusHandler::instance(this)->getFileInfo("kern");
+        QStringList filePaths = DLDBusHandler::instance()->getFileInfo("kern");
         for (auto file: filePaths) {
-            totalLineCount += DLDBusHandler::instance(this)->getLineCount(file);
+            totalLineCount += DLDBusHandler::instance()->getLineCount(file);
         }
     } else if (type == Kwin) {
         qCDebug(logApp) << "LogBackend::getNextSegementIndex Kwin";
-        totalLineCount = DLDBusHandler::instance(this)->getLineCount(KWIN_TREE_DATA);
+        totalLineCount = DLDBusHandler::instance()->getLineCount(KWIN_TREE_DATA);
     }
 
     // 计算分段段数

--- a/application/logcollectormain.cpp
+++ b/application/logcollectormain.cpp
@@ -353,7 +353,7 @@ void LogCollectorMain::exportAllLogs()
     // 导出路径白名单检查
     QFileInfo info(newPath);
     QString outPath = info.path();
-    QStringList availablePaths =  DLDBusHandler::instance(this)->whiteListOutPaths();
+    QStringList availablePaths =  DLDBusHandler::instance()->whiteListOutPaths();
 
     if (availablePaths.isEmpty()) {
         qCWarning(logApp) << "Failed to retrieve white list out paths, aborting export pre-check";
@@ -380,7 +380,7 @@ void LogCollectorMain::exportAllLogs()
 
     if (m_exportDlg == nullptr) {
         m_exportDlg = new ExportProgressDlg(this);
-        DLDBusHandler::instance(this);
+        DLDBusHandler::instance();
     }
     //导出是否完成
     bool exportcomplete = false;

--- a/application/logexportthread.cpp
+++ b/application/logexportthread.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -3944,7 +3944,7 @@ bool LogExportThread::exportToZip(const QString &fileName, const QList<LOG_MSG_C
     //复制文件
     int nCoreDumpCount = 0;
     for (auto &it : jList) {
-        DLDBusHandler::instance(this)->exportLog(tmpPath, it.storagePath, true);
+        DLDBusHandler::instance()->exportLog(tmpPath, it.storagePath, true);
         if (it.coreFile == "present")
             nCoreDumpCount++;
         if (!m_canRunning) {

--- a/application/logfileparser.cpp
+++ b/application/logfileparser.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -141,7 +141,7 @@ int LogFileParser::parseByDpkg(const DKPG_FILTERS &iDpkgFilter)
     stopAllLoad();
     LogAuthThread   *authThread = new LogAuthThread(this);
     authThread->setType(DPKG);
-    QStringList filePath = DLDBusHandler::instance(this)->getFileInfo("dpkg");
+    QStringList filePath = DLDBusHandler::instance()->getFileInfo("dpkg");
     //    const QString&str="/var/log/kern";
     authThread->setFilePath(filePath);
     authThread->setFileterParam(iDpkgFilter);
@@ -163,7 +163,7 @@ int LogFileParser::parseByXlog(const XORG_FILTERS &iXorgFilter)    // modifed by
     stopAllLoad();
     LogAuthThread   *authThread = new LogAuthThread(this);
     authThread->setType(XORG);
-    QStringList filePath = DLDBusHandler::instance(this)->getFileInfo("Xorg");
+    QStringList filePath = DLDBusHandler::instance()->getFileInfo("Xorg");
     authThread->setFilePath(filePath);
     authThread->setFileterParam(iXorgFilter);
     connect(authThread, &LogAuthThread::proccessError, this,
@@ -222,7 +222,7 @@ int LogFileParser::parseByBoot()
     LogAuthThread   *authThread = new LogAuthThread(this);
     authThread->setType(BOOT);
 
-    QStringList filePath = DLDBusHandler::instance(this)->getFileInfo("boot");
+    QStringList filePath = DLDBusHandler::instance()->getFileInfo("boot");
     authThread->setFilePath(filePath);
     connect(authThread, &LogAuthThread::bootFinished, this,
             &LogFileParser::bootFinished);
@@ -265,7 +265,7 @@ int LogFileParser::parseByKern(const KERN_FILTERS &iKernFilter)
     stopAllLoad();
     LogAuthThread   *authThread = new LogAuthThread(this);
     authThread->setType(KERN);
-    QStringList filePath = DLDBusHandler::instance(this)->getFileInfo("kern", false);
+    QStringList filePath = DLDBusHandler::instance()->getFileInfo("kern", false);
     authThread->setFileterParam(iKernFilter);
     authThread->setFilePath(filePath);
     connect(authThread, &LogAuthThread::kernFinished, this,
@@ -350,7 +350,7 @@ void LogFileParser::parseByDnf(DNF_FILTERS iDnfFilter)
     stopAllLoad();
     LogAuthThread *authThread = new LogAuthThread(this);
     authThread->setType(Dnf);
-    QStringList filePath = DLDBusHandler::instance(this)->getFileInfo("dnf");
+    QStringList filePath = DLDBusHandler::instance()->getFileInfo("dnf");
     authThread->setFilePath(filePath);
     authThread->setFileterParam(iDnfFilter);
     connect(authThread, &LogAuthThread::proccessError, this,
@@ -368,7 +368,7 @@ void LogFileParser::parseByDmesg(DMESG_FILTERS iDmesgFilter)
     stopAllLoad();
     LogAuthThread *authThread = new LogAuthThread(this);
     authThread->setType(Dmesg);
-    QStringList filePath = DLDBusHandler::instance(this)->getFileInfo("dmesg");
+    QStringList filePath = DLDBusHandler::instance()->getFileInfo("dmesg");
     authThread->setFilePath(filePath);
     authThread->setFileterParam(iDmesgFilter);
     connect(authThread, &LogAuthThread::proccessError, this,
@@ -406,7 +406,7 @@ int LogFileParser::parseByAudit(const AUDIT_FILTERS &iAuditFilter)
     stopAllLoad();
     LogAuthThread   *authThread = new LogAuthThread(this);
     authThread->setType(Audit);
-    QStringList filePath = DLDBusHandler::instance(this)->getFileInfo("audit", false);
+    QStringList filePath = DLDBusHandler::instance()->getFileInfo("audit", false);
     authThread->setFileterParam(iAuditFilter);
     authThread->setFilePath(filePath);
     connect(authThread, &LogAuthThread::auditFinished, this,

--- a/application/logoocfileparsethread.cpp
+++ b/application/logoocfileparsethread.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -76,7 +76,7 @@ void LogOOCFileParseThread::doWork()
         return;
     }
 
-    QStringList filePath = DLDBusHandler::instance(this)->getOtherFileInfo(m_path);
+    QStringList filePath = DLDBusHandler::instance()->getOtherFileInfo(m_path);
     qCDebug(logApp) << "Found" << filePath.count() << "files to process";
     for (int i = 0; i < filePath.count(); i++) {
         if (!m_canRun) {
@@ -93,7 +93,7 @@ void LogOOCFileParseThread::doWork()
         }
 
         qCDebug(logApp) << "Reading log file:" << filePath.at(i);
-        QString m_Log = DLDBusHandler::instance(this)->readLog(filePath.at(i));
+        QString m_Log = DLDBusHandler::instance()->readLog(filePath.at(i));
         m_fileData += m_Log;
         // dbus鉴权失败，不再继续解析
         if (m_Log.endsWith("is not allowed to configrate firewall. checkAuthorization failed.")) {
@@ -163,7 +163,7 @@ bool LogOOCFileParseThread::checkAuthentication(const QString &path)
 //        }
 //    }
 
-//    m_fileData = DLDBusHandler::instance(this)->readLog(m_path);
+//    m_fileData = DLDBusHandler::instance()->readLog(m_path);
 
 //    emit sigData(m_threadCount, m_fileData);
 //    emit sigFinished(m_threadCount);

--- a/application/main.cpp
+++ b/application/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,6 +13,7 @@
 #include "logbackend.h"
 #include "cliapplicationhelper.h"
 #include "accessible.h"
+#include "dbusproxy/dldbushandler.h"
 
 #include <DApplication>
 // #include <DApplicationSettings>
@@ -64,7 +65,9 @@ int main(int argc, char *argv[])
         LoggerRules logRules;
         logRules.initLoggerRules();
 #endif
-
+        // 提前在主线程创建 DLDBusHandler 单例，避免后续在子线程中首次调用
+        // 时不传 parent 而返回 nullptr 导致空指针崩溃。
+        DLDBusHandler::instance();
         QCommandLineOption exportOption(QStringList() << "e" << "export", DApplication::translate("main", "Export logs to the specified path"), DApplication::translate("main", "PATH"));
         QCommandLineOption typeOption(QStringList() << "t" << "type", DApplication::translate("main", "Export logs of specified types"), DApplication::translate("main", "TYPE"));
         QCommandLineOption appOption(QStringList() << "d" << "deepin-application", DApplication::translate("main", "Export logs of specified self-developed applications"), DApplication::translate("main", "SELF APPNAME"));
@@ -361,6 +364,10 @@ int main(int argc, char *argv[])
     logRules.initLoggerRules();
 #endif
         LogApplicationHelper::instance();
+
+        // 提前在主线程创建 DLDBusHandler 单例，避免后续在子线程中首次调用
+        // 时不传 parent 而返回 nullptr 导致空指针崩溃。
+        DLDBusHandler::instance();
 
         qCDebug(logApp) << "Checking single instance for application:" << a.applicationName();
         if (!DGuiApplicationHelper::instance()->setSingleInstance(a.applicationName(),

--- a/application/parsethread/parsethreadkern.cpp
+++ b/application/parsethread/parsethreadkern.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -51,7 +51,7 @@ void ParseThreadKern::handleKern()
     QList<QString> dataList;
     qint64 gStartLine = m_filter.segementIndex * SEGEMENT_SIZE;
     qCDebug(logApp) << "Global start line:" << gStartLine;
-    m_FilePath = DLDBusHandler::instance(this)->getFileInfo(m_filter.filePath, false);
+    m_FilePath = DLDBusHandler::instance()->getFileInfo(m_filter.filePath, false);
     qCDebug(logApp) << "Found" << m_FilePath.count() << "files to process";
     for (int i = 0; i < m_FilePath.count(); i++) {
         qCDebug(logApp) << "Processing file" << i << ":" << m_FilePath.at(i);
@@ -103,7 +103,7 @@ void ParseThreadKern::handleKern()
         //如果是压缩文件，对其解压缩
         QString filePath = m_FilePath.at(i);
         if(QString::compare(QFileInfo(filePath).suffix(), "gz", Qt::CaseInsensitive) == 0){
-            QStringList filePathList = DLDBusHandler::instance(this)->getFileInfo(filePath);
+            QStringList filePathList = DLDBusHandler::instance()->getFileInfo(filePath);
             if(filePathList.size()){
                 filePath = filePathList.at(0);
             }else {
@@ -111,7 +111,7 @@ void ParseThreadKern::handleKern()
             }
         }
 
-        qint64 lineCount = DLDBusHandler::instance(this)->getLineCount(filePath);
+        qint64 lineCount = DLDBusHandler::instance()->getLineCount(filePath);
         qCDebug(logApp) << "File line count:" << lineCount;
 
         // 获取全局起始行在当前文件的相对起始行位置
@@ -124,7 +124,7 @@ void ParseThreadKern::handleKern()
         qint64 startLine = gStartLine;
         qCDebug(logApp) << "Reading lines from" << startLine << "count:" << SEGEMENT_SIZE;
 
-        QStringList strList = DLDBusHandler::instance(this)->readLogLinesInRange(filePath, startLine, SEGEMENT_SIZE);
+        QStringList strList = DLDBusHandler::instance()->readLogLinesInRange(filePath, startLine, SEGEMENT_SIZE);
         for (int j = strList.size() - 1; j >= 0; --j) {
             if (!m_canRun) {
                 return;

--- a/application/parsethread/parsethreadkwin.cpp
+++ b/application/parsethread/parsethreadkwin.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -64,7 +64,7 @@ void ParseThreadKwin::handleKwin()
 
     qint64 gStartLine = m_filter.segementIndex * SEGEMENT_SIZE;
     qCDebug(logApp) << "Global start line:" << gStartLine;
-    qint64 lineCount = DLDBusHandler::instance(this)->getLineCount(KWIN_TREE_DATA);
+    qint64 lineCount = DLDBusHandler::instance()->getLineCount(KWIN_TREE_DATA);
     qCDebug(logApp) << "File line count:" << lineCount;
 
     // 获取全局起始行在当前文件的相对起始行位置
@@ -75,7 +75,7 @@ void ParseThreadKwin::handleKwin()
 
     qint64 startLine = gStartLine;
     qCDebug(logApp) << "Reading lines from" << startLine << "count:" << SEGEMENT_SIZE;
-    QStringList strList = DLDBusHandler::instance(this)->readLogLinesInRange(KWIN_TREE_DATA, startLine, SEGEMENT_SIZE);
+    QStringList strList = DLDBusHandler::instance()->readLogLinesInRange(KWIN_TREE_DATA, startLine, SEGEMENT_SIZE);
     if (!m_canRun) {
         return;
     }


### PR DESCRIPTION
The previous singleton required a non-null `parent` to create the instance: `instance()` returned nullptr when called without a parent (common in worker threads, e.g. `DLDBusHandler::instance()->executeCmd(...)`), which caused null-pointer crashes at runtime (e.g. logauththread.cpp:1536). The raw `if (m_statichandeler == nullptr)` check was also not thread-safe at construction time, risking duplicate instances on concurrent first calls.

Replace it with a standard Meyers singleton (C++11 function-local static), whose initialization is guaranteed thread-safe by the standard. Remove the now-unused `parent` parameter from `instance()` and the vestigial `m_statichandeler` pointer; the singleton owns its lifecycle and is reclaimed at process exit.

Update all ~40 call sites across 12 files to use the parameterless `instance()`:
  - `instance(this)` callers: logauththread, logfileparser, parsethreadkern/kwin, logapplicationparsethread, logoocfileparsethread, logexportthread, displaycontent, logcollectormain, logbackend
  - `instance(nullptr)` callers: logallexportthread, logbackend

Pre-heat the singleton on the main thread in main.cpp (both CLI and GUI paths) to ensure it is constructed before any worker thread uses it.

This is a minimal, behavior-preserving refactor: no new locking is added, so the existing shared-state usage (filePath/m_bGetFileInfoError and the fixed-name cache file Log_file_path.txt) remains as in the original code.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-374573.html

## Summary by Sourcery

Make DLDBusHandler a thread-safe, self-managed singleton to support reliable access across application and worker threads.

Bug Fixes:
- Prevent null-pointer crashes when DLDBusHandler is first accessed without a parent, including from worker threads.
- Ensure singleton initialization is safe during concurrent first access.

Enhancements:
- Replace the parent-dependent DLDBusHandler instance management with a standard parameterless singleton and update all call sites.
- Initialize the DLDBusHandler singleton during application startup on both CLI and GUI paths.