### PR TITLE
fix: clean up residual user-level coredump-reporter timer on upgrade

### DIFF
--- a/debian/deepin-log-viewer.postinst
+++ b/debian/deepin-log-viewer.postinst
@@ -8,18 +8,19 @@ userNameArr=($(who -q | head -n 1))
 #定时器名称
 sysTimer="coredump-reporter.timer"
 
-#根据已登录的用户更新定时器
+#根据已登录的用户清理用户级 timer 残留
+#旧版本曾将 timer 安装到 systemd/user 并通过 --user enable 启用,升级后必须无条件 stop+disable,
+#否则残留的用户级 timer 会以普通用户身份触发 coredump 上报,经 D-Bus 调用时因 caller 非 root
+#而触发 polkit 授权弹框
 for userName in ${userNameArr[@]} ; do
-    #获取定时器状态
-    serviceStatus=$(runuser -f -l ${userName} -c "XDG_RUNTIME_DIR=\"/run/user/$(id -u ${userName})\" systemctl --user is-active ${sysTimer}")
-    #活跃的关键字
-    activeStr="active"
-    #如果为活跃的则表示定时器已开启
-    if [ "$serviceStatus" = "$activeStr" ];then
-        runuser -f -l ${userName} -c "XDG_RUNTIME_DIR=\"/run/user/$(id -u ${userName})\" systemctl --user stop ${sysTimer}" || true
-        runuser -f -l ${userName} -c "XDG_RUNTIME_DIR=\"/run/user/$(id -u ${userName})\" systemctl --user daemon-reload" || true
-    fi
+    runuser -f -l ${userName} -c "XDG_RUNTIME_DIR=\"/run/user/$(id -u ${userName})\" systemctl --user stop ${sysTimer}" || true
+    runuser -f -l ${userName} -c "XDG_RUNTIME_DIR=\"/run/user/$(id -u ${userName})\" systemctl --user disable ${sysTimer}" || true
+    runuser -f -l ${userName} -c "XDG_RUNTIME_DIR=\"/run/user/$(id -u ${userName})\" systemctl --user daemon-reload" || true
 done
+
+# 清理可能残留的用户级 unit 文件(旧版本安装到 lib/systemd/user/)
+rm -f /usr/lib/systemd/user/coredump-reporter.timer 2>/dev/null || true
+rm -f /usr/lib/systemd/user/coredump-reporter.service 2>/dev/null || true
 
 # 启用系统级 timer
 if [ -f /lib/systemd/system/coredump-reporter.timer ]; then


### PR DESCRIPTION
# fix: clean up residual user-level coredump-reporter timer on upgrade

## 问题

低版本 deepin-log-viewer 升级到新版本后，开机 5 分钟后弹出鉴权窗口，之后每 15 分钟弹出一次。

## 根因

旧版本将 `coredump-reporter.timer` 和 `coredump-reporter.service` 安装为用户级 systemd unit（`/usr/lib/systemd/user/`）。新版本迁移到系统级 unit（`/usr/lib/systemd/system/`），但 `debian/deepin-log-viewer.postinst` 升级脚本清理不完整：

1. 仅在 timer 处于 `active` 状态时才 `stop`，未 `disable`，timer 可被重新触发。
2. 未删除 `/usr/lib/systemd/user/` 下的残留 unit 文件。

残留的用户级 timer 以普通用户身份触发 coredump 上报，经 D-Bus 调用系统服务时因 caller 非 root 而触发 polkit 授权弹框。

## 修复

修改 `debian/deepin-log-viewer.postinst`：

1. 无条件 `stop` + `disable` 用户级 timer（不再仅在 active 时 stop）。
2. 删除 `/usr/lib/systemd/user/coredump-reporter.timer` 和 `coredump-reporter.service` 残留文件。
3. 所有命令加 `|| true` 确保不会因清理失败导致包安装失败。

## 测试

已由用户验证：升级后开机不再弹出鉴权窗口。

## 关联

- PMS: https://pms.uniontech.com/bug-view-375241.html

## Summary by Sourcery

Bug Fixes:
- Clean up residual user-level coredump-reporter timers and services during package upgrades to prevent recurring polkit authentication prompts.