### PR TITLE
fix(security): chmod target must be export path, not its parent dir

### DIFF
--- a/application/utils.cpp
+++ b/application/utils.cpp
@@ -503,13 +503,7 @@ void Utils::resetToNormalAuth(const QString &path)
     QFileInfo fi(path);
     if (!path.isEmpty() && fi.exists()) {
         qInfo() << "resetToNormalAuth: " << path;
-        QString tmpPath = path;
-        if (fi.isDir())
-            tmpPath = path;
-        else
-            tmpPath = fi.absolutePath();
-
-        executeCmd("chmod", QStringList() << "-R" << "777" << tmpPath);
+        executeCmd("chmod", QStringList() << "-R" << "777" << path);
     }
 }
 


### PR DESCRIPTION
resetToNormalAuth incorrectly used fi.absolutePath() as chmod target when path is a file, recursively chmod 777 the parent directory.

resetToNormalAuth 在 path 为文件时误用 fi.absolutePath() 作为 chmod 目标，导致递归 chmod 777 父目录，扩大权限至无关文件。

Log: 修复导出后chmod递归放宽父目录权限的问题
PMS: BUG-375123
Influence: 按条件导出日志到文件时不再递归修改父目录权限，仅作用于导出产物本身。

## Summary by Sourcery

Bug Fixes:
- Ensure exported files have their permissions reset without recursively changing permissions on the containing directory or unrelated files.