### PR TITLE
fix(security): authorize D-Bus method

### DIFF
--- a/application/utils.cpp
+++ b/application/utils.cpp
@@ -445,13 +445,7 @@ void Utils::resetToNormalAuth(const QString &path)
     QFileInfo fi(path);
     if (!path.isEmpty() && fi.exists()) {
         qInfo() << "resetToNormalAuth: " << path;
-        QString tmpPath = path;
-        if (fi.isDir())
-            tmpPath = path;
-        else
-            tmpPath = fi.absolutePath();
-
-        executeCmd("chmod", QStringList() << "-R" << "777" << tmpPath);
+        executeCmd("chmod", QStringList() << "-R" << "777" << path);
     }
 }
 

--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -40,6 +40,7 @@ using namespace PolkitQt1;
 #include <QFile>
 #include <QDir>
 #include <QTemporaryDir>
+#include <QUuid>
 
 #ifdef QT_DEBUG
 Q_LOGGING_CATEGORY(logService, "org.deepin.log.viewer.service")
@@ -569,7 +570,10 @@ QString LogViewerService::openLogStream(const QString &filePath)
         return "";
     }
 
-    QString token = QCryptographicHash::hash(filePath.toUtf8(), QCryptographicHash::Md5).toHex();
+    // 使用随机 UUID 作为 token，替代可预测的 MD5(filePath)。
+    // 旧方案下攻击者只需知道文件路径即可计算 token，无需经过 openLogStream，
+    // 进而通过无鉴权的 readLogInStream 窃取其他用户缓存的日志。
+    QString token = QUuid::createUuid().toString(QUuid::WithoutBraces);
 
     auto stream = new QTextStream;
 
@@ -587,6 +591,11 @@ QString LogViewerService::openLogStream(const QString &filePath)
 QString LogViewerService::readLogInStream(const QString &token)
 {
     trackCurrentCaller();
+    if (!checkAuth(s_Action_View)) {
+        qWarning() << "Authorization check failed for readLogInStream";
+        return "";
+    }
+
     if(!m_logMap.contains(token)) {
         return "";
     }

--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -754,6 +754,9 @@ void LogViewerService::clearTempFiles()
 int LogViewerService::exitCode()
 {
     trackCurrentCaller();
+    if (!checkAuth(s_Action_View)) {
+        return -1;
+    }
     return m_process.exitCode();
 }
 

--- a/logViewerService/logviewerservice.cpp
+++ b/logViewerService/logviewerservice.cpp
@@ -1373,7 +1373,18 @@ bool LogViewerService::checkAuth(const QString &actionId)
         return false;
     }
 
-    bool isRoot = connection().interface()->serviceUid(message().service()).value() == 0;
+    // 显式校验 D-Bus 回复有效性：serviceUid() 失败时 QDBusReply::value() 会静默
+    // 返回默认构造值 0，若直接当作 UID 会与 root(0) 混淆，构成 fail-open——
+    // 任何 D-Bus 调用者都能借此绕过 Polkit 被当作 root 放行。此处对无效回复
+    // fail-closed，拒绝访问并回 Failed，绝不回退为 root。
+    auto reply = connection().interface()->serviceUid(message().service());
+    if (!reply.isValid()) {
+        qWarning() << "checkAuth denied: failed to get caller UID via D-Bus:"
+                   << reply.error().message();
+        sendErrorReply(QDBusError::ErrorType::Failed, "failed to get caller UID");
+        return false;
+    }
+    bool isRoot = reply.value() == 0;
     if (isRoot) {
         qInfo() << "dbus caller is root progress.";
         return  true;


### PR DESCRIPTION
## Summary by Sourcery

Strengthen D-Bus authorization and log-stream access controls to prevent unauthorized data access and privilege bypasses.

Bug Fixes:
- Require authorization for reading log streams and querying process exit codes over D-Bus.
- Prevent predictable log-stream tokens from enabling unauthorized access to cached logs.
- Fail closed when caller UID lookup fails instead of incorrectly treating the caller as root.
- Apply recursive permission changes to the requested path directly.