### PR TITLE
fix: remove unsupported -l switch from 7z command in crash log export

### DIFF
--- a/application/logexportthread.cpp
+++ b/application/logexportthread.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -3835,7 +3835,8 @@ bool LogExportThread::exportToZip(const QString &fileName, const QList<LOG_MSG_C
     }
 
     // 使用7z进行压缩，方便获取进度
-    procss.start("7z", QStringList() << "a" << "-l" << "-bsp1" << "tmp.zip" << "./");
+    // 注意：-l 是 p7zip 专有开关，移除以兼容所有版本
+    procss.start("7z", QStringList() << "a" << "-bsp1" << "tmp.zip" << "./");
     procss.waitForFinished(-1);
 
     procss.start("mv", QStringList() << "tmp.zip" << fileName);


### PR DESCRIPTION
The -l switch is a p7zip-specific extension that is not recognized by 7-Zip for Linux 21+ (including 26.02). When the system has a newer 7z version, the command fails with "Unknown switch: -l", producing no stdout output. As a result, the readyReadStandardOutput signal never fires, the `ret` variable stays false, and the export is incorrectly reported as failed.

Remove the -l switch so that the 7z command runs successfully across all versions, allowing the compression progress to be read normally and the export to complete successfully.

Fixes: crash log export showing "导出失败" (export failed) on systems with 7-Zip 26.02 while working on systems with p7zip 16.02.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-375251.html

## Summary by Sourcery

Ensure crash log compression works across supported 7-Zip versions and reports successful exports correctly.

Bug Fixes:
- Fix crash log exports failing on newer Linux 7-Zip versions by removing the unsupported command-line switch.

Chores:
- Update the copyright year in the affected source file.