### PR TITLE
fix: add AT-SPI accessible names for interactive widgets

### DIFF
--- a/application/displaycontent.cpp
+++ b/application/displaycontent.cpp
@@ -183,6 +183,7 @@ void DisplayContent::initUI()
 
 
     m_menu = new QMenu(m_treeView);
+    m_menu->setObjectName("Menu");
     m_menu->setAccessibleName("table_menu");
     m_act_openForder = m_menu->addAction(/*tr("在文件管理器中显示")*/ DApplication::translate("Action", "Display in file manager"));
     m_act_refresh = m_menu->addAction(/*tr("刷新")*/ DApplication::translate("Action", "Refresh"));

--- a/application/filtercontent.cpp
+++ b/application/filtercontent.cpp
@@ -76,23 +76,36 @@ void FilterContent::initUI()
     periodLabel = new DLabel(DApplication::translate("Label", "Period:"), this);
     periodLabel->setAlignment(Qt::AlignRight | Qt::AlignCenter);
     m_btnGroup = new QButtonGroup(this);
+    m_btnGroup->setObjectName("BtnGroup");
     //初始化时间筛选按钮部分布局
     m_allBtn = new LogPeriodButton(DApplication::translate("Button", "All"), this);
+    m_allBtn->setObjectName("AllBtn");
+    m_allBtn->setAccessibleName("AllBtn");
     m_allBtn->setToolTip(DApplication::translate("Button", "All"));  // add by Airy for bug 16245
     m_btnGroup->addButton(m_allBtn, 0);
     m_todayBtn = new LogPeriodButton(DApplication::translate("Button", "Today"), this);
+    m_todayBtn->setObjectName("TodayBtn");
+    m_todayBtn->setAccessibleName("TodayBtn");
     m_todayBtn->setToolTip(DApplication::translate("Button", "Today"));  // add by Airy for bug
     m_btnGroup->addButton(m_todayBtn, 1);
     m_threeDayBtn = new LogPeriodButton(DApplication::translate("Button", "3 days"), this);
+    m_threeDayBtn->setObjectName("ThreeDayBtn");
+    m_threeDayBtn->setAccessibleName("ThreeDayBtn");
     m_threeDayBtn->setToolTip(DApplication::translate("Button", "3 days")); // add by Airy for bug 16245
     m_btnGroup->addButton(m_threeDayBtn, 2);
     m_lastWeekBtn = new LogPeriodButton(DApplication::translate("Button", "1 week"), this);
+    m_lastWeekBtn->setObjectName("LastWeekBtn");
+    m_lastWeekBtn->setAccessibleName("LastWeekBtn");
     m_lastWeekBtn->setToolTip(DApplication::translate("Button", "1 week")); // add by Airy for bug 16245
     m_btnGroup->addButton(m_lastWeekBtn, 3);
     m_lastMonthBtn = new LogPeriodButton(DApplication::translate("Button", "1 month"), this);
+    m_lastMonthBtn->setObjectName("LastMonthBtn");
+    m_lastMonthBtn->setAccessibleName("LastMonthBtn");
     m_lastMonthBtn->setToolTip(DApplication::translate("Button", "1 month")); // add by Airy for bug 16245
     m_btnGroup->addButton(m_lastMonthBtn, 4);
     m_threeMonthBtn = new LogPeriodButton(DApplication::translate("Button", "3 months"), this);
+    m_threeMonthBtn->setObjectName("ThreeMonthBtn");
+    m_threeMonthBtn->setAccessibleName("ThreeMonthBtn");
     m_threeMonthBtn->setToolTip(DApplication::translate("Button", "3 months")); // add by Airy for bug 16245
     m_btnGroup->addButton(m_threeMonthBtn, 5);
     //设置初始时间筛选为全部
@@ -136,6 +149,8 @@ void FilterContent::initUI()
     dnflvTxt->setAccessibleName("dnf" + DApplication::translate("Label", "Level:  "));
     dnflvTxt->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     cbx_dnf_lv = new LogCombox(this);
+    cbx_dnf_lv->setObjectName("CbxDnfLv");
+    cbx_dnf_lv->setAccessibleName("CbxDnfLv");
     //cbx_dnf_lv->view()->setAccessibleName("combobox_dnflevel_view");
     cbx_dnf_lv->setMinimumWidth(198);
     cbx_dnf_lv->addItem(DApplication::translate("ComboBox", "All"), DNFLVALL);
@@ -166,6 +181,8 @@ void FilterContent::initUI()
     QHBoxLayout *hLayout_submodule = new QHBoxLayout;
     submoduleTxt = new DLabel(DApplication::translate("Label", "Submodule:"), this);
     cbx_submodule = new LogCombox(this);
+    cbx_submodule->setObjectName("CbxSubmodule");
+    cbx_submodule->setAccessibleName("CbxSubmodule");
     //cbx_submodule->view()->setAccessibleName("combobox_submodule_view");
 
     cbx_submodule->setMinimumWidth(143);
@@ -207,6 +224,8 @@ void FilterContent::initUI()
     QHBoxLayout *hLayout_auditType = new QHBoxLayout;
     auditTypeTxt = new DLabel(DApplication::translate("Label", "Audit Type:"), this);
     auditTypeCbx = new LogCombox(this);
+    auditTypeCbx->setObjectName("AuditTypeCbx");
+    auditTypeCbx->setAccessibleName("AuditTypeCbx");
     auditTypeCbx->setMinimumWidth(120);
     auditTypeCbx->addItems(QStringList() << DApplication::translate("ComboBox", "All")
                       << DApplication::translate("ComboBox", "Identity authentication")
@@ -222,6 +241,8 @@ void FilterContent::initUI()
 
     hLayout_all->addStretch(1);
     exportBtn = new LogNormalButton(DApplication::translate("Button", "Export", "button"), this);
+    exportBtn->setObjectName("ExportBtn");
+    exportBtn->setAccessibleName("ExportBtn");
     exportBtn->setContentsMargins(0, 0, 18, 18);
     exportBtn->setFixedWidth(BUTTON_EXPORT_WIDTH_MIN);
     hLayout_all->addWidget(exportBtn);
@@ -404,9 +425,13 @@ void FilterContent::setSelectorVisible(bool lvCbx, bool appListCbx, bool statusC
     setUpdatesEnabled(true);
 
     cbx_lv->setObjectName("level_combox");
+    cbx_lv->setAccessibleName("CbxLv");
     cbx_app->setObjectName("app_combox");
+    cbx_app->setAccessibleName("CbxApp");
     cbx_status->setObjectName("status_combox");
+    cbx_status->setAccessibleName("CbxStatus");
     typeCbx->setObjectName("event_type_combox");
+    typeCbx->setAccessibleName("TypeCbx");
 }
 
 /**

--- a/application/logcollectormain.cpp
+++ b/application/logcollectormain.cpp
@@ -101,6 +101,7 @@ void LogCollectorMain::initUI()
     qCDebug(logApp) << "Initializing UI components...";
     /** add searchEdit */
     m_searchEdt = new DSearchEdit();
+    m_searchEdt->setAccessibleName("SearchEdt");
 
     m_searchEdt->setPlaceHolder(DApplication::translate("SearchBar", "Search"));
     m_searchEdt->setMaximumWidth(400);
@@ -226,12 +227,14 @@ void LogCollectorMain::initTitlebarExtensions()
     DWidget *widget = new DWidget;
     QHBoxLayout *layout = new QHBoxLayout(widget);
     m_exportAllBtn = new DIconButton(widget);
+    m_exportAllBtn->setObjectName("ExportAllBtn");
     m_exportAllBtn->setFixedSize(QSize(36, 36));
     m_exportAllBtn->setIcon(QIcon::fromTheme("export"));
     m_exportAllBtn->setIconSize(QSize(36, 36));
     m_exportAllBtn->setToolTip(qApp->translate("titlebar", "Export All"));
     m_exportAllBtn->setAccessibleName(qApp->translate("titlebar", "Export All"));
     m_refreshBtn = new DIconButton(widget);
+    m_refreshBtn->setObjectName("RefreshBtn");
     m_refreshBtn->setIcon(QIcon::fromTheme("refresh"));
     m_refreshBtn->setFixedSize(QSize(36, 36));
     m_refreshBtn->setIconSize(QSize(36, 36));
@@ -534,6 +537,7 @@ void LogCollectorMain::initShortCut()
     // Resize Window --> Ctrl+Alt+F
     if (nullptr == m_scWndReize) {
         m_scWndReize = new QShortcut(this);
+        m_scWndReize->setObjectName("ScWndReize");
         qCDebug(logApp) << "Created window resize shortcut";
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         m_scWndReize->setKey(Qt::CTRL + Qt::ALT + Qt::Key_F);
@@ -557,6 +561,7 @@ void LogCollectorMain::initShortCut()
     // Find font --> Ctrl+F
     if (nullptr == m_scFindFont) {
         m_scFindFont = new QShortcut(this);
+        m_scFindFont->setObjectName("ScFindFont");
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         m_scFindFont->setKey(Qt::CTRL + Qt::Key_F);
 #else
@@ -572,6 +577,7 @@ void LogCollectorMain::initShortCut()
     // export file --> Ctrl+E
     if (nullptr == m_scExport) {
         m_scExport = new QShortcut(this);
+        m_scExport->setObjectName("ScExport");
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         m_scExport->setKey(Qt::CTRL + Qt::Key_E);
 #else

--- a/application/logdetailinfowidget.cpp
+++ b/application/logdetailinfowidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -121,6 +121,8 @@ void logDetailInfoWidget::initUI()
     m_status->setMinimumWidth(LABEL_MIN_WIDTH);
 
     m_level = new LogIconButton(this);
+    m_level->setObjectName("Level");
+    m_level->setAccessibleName("Level");
     DFontSizeManager::instance()->bind(m_level, DFontSizeManager::T8);
 
     // add by Airy
@@ -155,6 +157,8 @@ void logDetailInfoWidget::initUI()
 
     //不设置nofocus焦点会上到这上面来,可是我们不需要它可以有焦点
     m_textBrowser->setFocusPolicy(Qt::NoFocus);
+    m_textBrowser->setObjectName("TextBrowser");
+    m_textBrowser->setAccessibleName("TextBrowser");
     DFontSizeManager::instance()->bind(m_textBrowser, DFontSizeManager::T8);
     m_textBrowser->setFrameShape(QFrame::NoFrame);
     m_textBrowser->viewport()->setAutoFillBackground(false);

--- a/application/loglistview.cpp
+++ b/application/loglistview.cpp
@@ -138,6 +138,7 @@ LogListView::LogListView(QWidget *parent)
     //DGuiApplicationHelper::ColorType ct = DGuiApplicationHelper::instance()->themeType();
 
     m_rightClickTriggerShortCut = new QShortcut(this);
+    m_rightClickTriggerShortCut->setObjectName("RightClickTriggerShortCut");
     #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         m_rightClickTriggerShortCut->setKey(Qt::ALT + Qt::Key_M);
     #else
@@ -527,9 +528,14 @@ void LogListView::showRightMenu(const QPoint &pos, bool isUsePoint)
     QString pathData = idx.data(ITEM_DATE_ROLE).toString();
     if (!this->selectionModel()->selectedIndexes().empty()) {
         g_context = new QMenu(this);
+        g_context->setObjectName("GContext");
+        g_context->setAccessibleName("GContext");
         g_openForder = new QAction(/*tr("在文件管理器中显示")*/ DApplication::translate("Action", "Display in file manager"), this);
+        g_openForder->setObjectName("GOpenForder");
         g_clear = new QAction(/*tr("清除日志内容")*/ DApplication::translate("Action", "Clear log"), this);
+        g_clear->setObjectName("GClear");
         g_refresh = new QAction(/*tr("刷新")*/ DApplication::translate("Action", "Refresh"), this);
+        g_refresh->setObjectName("GRefresh");
 
         g_context->addAction(g_openForder);
         g_context->addAction(g_clear);

--- a/application/logtreeview.cpp
+++ b/application/logtreeview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -78,6 +78,8 @@ void LogTreeView::initUI()
     setItemDelegate(m_itemDelegate);
 
     m_headerDelegate = new LogViewHeaderView(Qt::Horizontal, this);
+    m_headerDelegate->setObjectName("HeaderDelegate");
+    m_headerDelegate->setAccessibleName("HeaderDelegate");
     setHeader(m_headerDelegate);
 
     this->setEditTriggers(QAbstractItemView::NoEditTriggers);


### PR DESCRIPTION
## AT-SPI Accessibility Name Completion

为 `deepin-log-viewer` 仓库中的交互控件补全 AT-SPI 无障碍名称。

### 覆盖率变化
| 指标 | 补全前 | 补全后 |
|------|--------|--------|
| 已命名控件 | 10 | 40 |
| 缺失控件 | 30 | 0 |
| 覆盖率 | 25.0% | 100.0% |

### 修改文件 (6 files, +44 lines)
- `application/displaycontent.cpp` — QMenu
- `application/filtercontent.cpp` — QButtonGroup, LogCombox ×7, LogPeriodButton ×6, LogNormalButton
- `application/logcollectormain.cpp` — DSearchEdit, QShortcut ×3, DIconButton ×2
- `application/logdetailinfowidget.cpp` — LogIconButton, logDetailEdit
- `application/loglistview.cpp` — QMenu, QAction ×3, QShortcut
- `application/logtreeview.cpp` — LogViewHeaderView

### 验证
- 本地编译通过 (cmake + make, 0 errors)
- quality_gate.py 重新扫描确认覆盖率 100%, 0 gaps, 0 new gaps

## Summary by Sourcery

Complete AT-SPI naming for interactive log viewer widgets to provide full accessibility coverage.

Bug Fixes:
- Complete AT-SPI accessibility names for interactive widgets across the log viewer, eliminating previously missing accessibility labels.

Enhancements:
- Add consistent object identifiers to menus, controls, shortcuts, actions, and views to improve accessibility coverage and UI component identification.

Tests:
- Verify the accessibility scan reaches 100% named-widget coverage with no gaps.