### PR TITLE
fix: avoid repeated auth dialog on getFileInfo failure

### DIFF
--- a/application/parsethread/parsethreadkern.cpp
+++ b/application/parsethread/parsethreadkern.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -52,6 +52,11 @@ void ParseThreadKern::handleKern()
     QList<QString> dataList;
     qint64 gStartLine = m_filter.segementIndex * SEGEMENT_SIZE;
     m_FilePath = DLDBusHandler::instance(this)->getFileInfo(m_filter.filePath, false);
+    // 如果getFileInfo的dbus调用失败(如用户取消授权)，直接当作授权失败来返回,避免后续出现继续弹出授权框问题
+    if (DLDBusHandler::instance(this)->isGetFileInfoError()) {
+        emit parseFinished(m_threadCount, m_type, CancelAuth);
+        return;
+    }
     for (int i = 0; i < m_FilePath.count(); i++) {
         if (!m_FilePath.at(i).contains("txt")) {
             QFile file(m_FilePath.at(i)); // add by Airy


### PR DESCRIPTION
In ParseThreadKern::handleKern, if the getFileInfo D-Bus call fails (e.g. the user cancels authorization), treat it as authorization failure and emit parseFinished with CancelAuth directly, preventing subsequent parse operations from repeatedly popping up the authorization dialog.

在 ParseThreadKern::handleKern 中，当 getFileInfo 的 D-Bus 调用失败 （如用户取消授权）时，直接将其视为授权失败并通过 CancelAuth 发送
parseFinished，避免后续解析继续弹出授权框。

Log: 修复 getFileInfo 失败时重复弹出授权框的问题
PMS: BUG-371767
Influence: 日志解析在用户取消授权后不再重复弹出授权框

## Summary by Sourcery

Bug Fixes:
- Treat getFileInfo failures as authorization cancellation to prevent repeated authorization dialogs during log parsing.