### PR TITLE
chore: update version to 6.5.39

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-log-viewer (6.5.39) unstable; urgency=medium
+
+  * fix: add AT-SPI accessible names for interactive widgets
+  * [skip CI] Translate deepin-log-viewer.ts in sv
+  * [skip CI] Translate deepin-log-viewer.ts in ar
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Mon, 07 Sep 2026 13:36:25 +0800
+
 deepin-log-viewer (6.5.38) unstable; urgency=medium
 
   * fix(security): chmod target must be export path, not its parent dir


### PR DESCRIPTION
as title

Log: update version

## Summary by Sourcery

Chores:
- Update the Debian package changelog for version 6.5.39.